### PR TITLE
Refactor config

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -12,12 +12,6 @@
 
 process {
 
-    publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-    ]
-
     withName: SAMPLESHEET_CHECK {
         publishDir = [
             path: { "${params.outdir}/pipeline_info" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -43,7 +43,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.run_accession}_raw" }
         publishDir = [
             path: { "${params.outdir}/fastqc/raw" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.html'
         ]
     }
@@ -53,7 +53,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.run_accession}_processed" }
         publishDir = [
             path: { "${params.outdir}/fastqc/processed" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.html'
         ]
     }
@@ -69,7 +69,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
             path: { "${params.outdir}/fastp" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.fastq.gz'
         ]
     }
@@ -88,7 +88,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
             path: { "${params.outdir}/fastp" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.fastq.gz'
         ]
     }
@@ -104,7 +104,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
             path: { "${params.outdir}/adapterremoval" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.fastq.gz'
         ]
     }
@@ -123,7 +123,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
             path: { "${params.outdir}/adapterremoval" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.fastq.gz'
         ]
     }
@@ -132,7 +132,7 @@ process {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
             path: { "${params.outdir}/porechop" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.fastq.gz'
         ]
     }
@@ -169,7 +169,7 @@ process {
         ext.prefix = { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
             path: { "${params.outdir}/malt/${meta.db_name}" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.{rma6,tab,text,sam,log}'
         ]
     }
@@ -179,7 +179,7 @@ process {
         ext.prefix = { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
             path: { "${params.outdir}/kraken2/${meta.db_name}" },
-            mode: 'copy',
+            mode: params.publish_dir_mode,
             pattern: '*.{fastq.gz,txt}'
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,7 +35,7 @@ process {
     }
 
     withName: UNTAR {
-        publishDir = null
+        publishDir = [enabled: false]
     }
 
     withName: FASTQC {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -28,10 +28,6 @@ process {
         ]
     }
 
-    withName: UNTAR {
-        publishDir = [enabled: false]
-    }
-
     withName: FASTQC {
         ext.args = '--quiet'
         ext.prefix = { "${meta.id}_${meta.run_accession}_raw" }
@@ -64,7 +60,8 @@ process {
         publishDir = [
             path: { "${params.outdir}/fastp" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq.gz'
+            pattern: '*.fastq.gz',
+            enabled: params.save_preprocessed_reads
         ]
     }
 
@@ -83,7 +80,8 @@ process {
         publishDir = [
             path: { "${params.outdir}/fastp" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq.gz'
+            pattern: '*.fastq.gz',
+            enabled: params.save_preprocessed_reads
         ]
     }
 
@@ -99,7 +97,8 @@ process {
         publishDir = [
             path: { "${params.outdir}/adapterremoval" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq.gz'
+            pattern: '*.fastq.gz',
+            enabled: params.save_preprocessed_reads
         ]
     }
 
@@ -118,7 +117,8 @@ process {
         publishDir = [
             path: { "${params.outdir}/adapterremoval" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq.gz'
+            pattern: '*.fastq.gz',
+            enabled: params.save_preprocessed_reads
         ]
     }
 
@@ -127,7 +127,8 @@ process {
         publishDir = [
             path: { "${params.outdir}/porechop" },
             mode: params.publish_dir_mode,
-            pattern: '*.fastq.gz'
+            pattern: '*.fastq.gz',
+            enabled: params.save_preprocessed_reads
         ]
     }
 
@@ -141,7 +142,8 @@ process {
         publishDir = [
             path: { "${params.outdir}/bbduk/" },
             mode: params.publish_dir_mode,
-            pattern: '*.{fastq.gz,log}'
+            pattern: '*.{fastq.gz,log}',
+            enabled: params.save_complexityfiltered_reads
         ]
     }
 
@@ -154,7 +156,8 @@ process {
         publishDir = [
             path: { "${params.outdir}/prinseqplusplus/" },
             mode: params.publish_dir_mode,
-            pattern: '*{_good_out.fastq.gz,_good_out_R1.fastq.gz,_good_out_R2.fastq.gz,log}'
+            pattern: '*{_good_out.fastq.gz,_good_out_R1.fastq.gz,_good_out_R2.fastq.gz,log}',
+            enabled: params.save_complexityfiltered_reads
         ]
     }
 

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,11 +35,7 @@ process {
     }
 
     withName: UNTAR {
-        publishDir = [
-            path: { "${params.outdir}/databases" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
-        ]
+        publishDir = null
     }
 
     withName: FASTQC {

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,6 +64,7 @@ params {
     shortread_clipmerge_adapter2            = null
     shortread_clipmerge_minlength           = 15
     longread_clip                           = false
+    save_preprocessed_reads                 = false
 
     // Complexity filtering
     shortread_complexityfilter                           = false
@@ -73,6 +74,7 @@ params {
     shortread_complexityfilter_bbduk_mask                = false
     shortread_complexityfilter_prinseqplusplus_mode      = 'entropy'
     shortread_complexityfilter_prinseqplusplus_dustscore = 0.5
+    save_complexityfiltered_reads                        = false
 
 
     // MALT

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -308,6 +308,10 @@
             "type": "integer",
             "default": 15
         },
+        "save_preprocessed_reads": {
+            "type": "boolean",
+            "default": false
+        },
         "shortread_complexityfilter_tool": {
             "type": "string",
             "default": "bbduk"
@@ -334,6 +338,10 @@
         "shortread_complexityfilter_prinseqplusplus_dustscore": {
             "type": "number",
             "default": 0.5
+        },
+        "save_complexityfiltered_reads": {
+            "type": "boolean",
+            "default": false
         }
     }
 }


### PR DESCRIPTION
Address comments from Slack:

1. We are currently publishing the results from `UNTAR` in the databases directory. Since the databases are required input already, this seems pointless to me and only wastes disk space.
2. We use a mix of `mode: 'copy'` and `mode: params.publish_dir_mode` in the modules.config. I prefer the latter but I know there was some switch. Either way, we should be consistent.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
