### PR TITLE
Add finer control over for hostremoval saving

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -137,29 +137,31 @@ process {
             path: { "${params.outdir}/bowtie2/build" },
             mode: params.publish_dir_mode,
             enabled: params.save_hostremoval_index,
-            pattern: 'bowtie2/*'
+            pattern: 'bowtie2'
         ]
     }
 
     withName: BOWTIE2_ALIGN {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
-        publishDir = [[
+        publishDir = [
+            [
             path: { "${params.outdir}/bowtie2/align" },
             mode: params.publish_dir_mode,
             pattern: '*.log'
-        ],
-        [
+            ],
+            [
             path: { "${params.outdir}/bowtie2/align" },
             mode: params.publish_dir_mode,
             enabled: params.save_hostremoval_mapped,
             pattern: '*.bam'
-        ],
-        publishDir = [
+            ],
+            [
             path: { "${params.outdir}/bowtie2/align" },
             mode: params.publish_dir_mode,
             enabled: params.save_hostremoval_unmapped,
             pattern: '*.fastq.gz'
-        ]]
+            ]
+        ]
     }
 
     withName: BBMAP_BBDUK {

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -133,21 +133,33 @@ process {
     }
 
     withName: BOWTIE2_BUILD {
-        ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
             path: { "${params.outdir}/bowtie2/build" },
             mode: params.publish_dir_mode,
-            pattern: '*.bt2'
+            enabled: params.save_hostremoval_index,
+            pattern: 'bowtie2/*'
         ]
     }
 
     withName: BOWTIE2_ALIGN {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
+        publishDir = [[
+            path: { "${params.outdir}/bowtie2/align" },
+            mode: params.publish_dir_mode,
+            pattern: '*.log'
+        ],
+        [
+            path: { "${params.outdir}/bowtie2/align" },
+            mode: params.publish_dir_mode,
+            enabled: params.save_hostremoval_mapped,
+            pattern: '*.bam'
+        ],
         publishDir = [
             path: { "${params.outdir}/bowtie2/align" },
             mode: params.publish_dir_mode,
-            pattern: '*.{fastq.gz,bam}'
-        ]
+            enabled: params.save_hostremoval_unmapped,
+            pattern: '*.fastq.gz'
+        ]]
     }
 
     withName: BBMAP_BBDUK {

--- a/nextflow.config
+++ b/nextflow.config
@@ -82,8 +82,11 @@ params {
 
     // Host Removal
     perform_shortread_hostremoval     = false
-    shortread_hostremoval_reference = null
-    shortread_hostremoval_index     = null
+    shortread_hostremoval_reference   = null
+    shortread_hostremoval_index       = null
+    save_hostremoval_index            = false
+    save_hostremoval_mapped           = false
+    save_hostremoval_unmapped         = false
 
     // MALT
     run_malt                   = false

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,10 +10,7 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": [
-                "input",
-                "outdir"
-            ],
+            "required": ["input", "outdir"],
             "properties": {
                 "input": {
                     "type": "string",
@@ -176,14 +173,7 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": [
-                        "symlink",
-                        "rellink",
-                        "link",
-                        "copy",
-                        "copyNoFollow",
-                        "move"
-                    ],
+                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
                     "hidden": true
                 },
                 "email_on_fail": {
@@ -304,10 +294,7 @@
         "shortread_clipmerge_tool": {
             "type": "string",
             "default": "fastp",
-            "enum": [
-                "fastp",
-                "adapterremoval"
-            ]
+            "enum": ["fastp", "adapterremoval"]
         },
         "shortread_clipmerge_skipadaptertrim": {
             "type": "boolean"
@@ -348,10 +335,7 @@
         "shortread_complexityfilter_prinseqplusplus_mode": {
             "type": "string",
             "default": "entropy",
-            "enum": [
-                "entropy",
-                "dust"
-            ]
+            "enum": ["entropy", "dust"]
         },
         "shortread_complexityfilter_prinseqplusplus_dustscore": {
             "type": "number",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -10,7 +10,10 @@
             "type": "object",
             "fa_icon": "fas fa-terminal",
             "description": "Define where the pipeline should find input data and save output data.",
-            "required": ["input", "outdir"],
+            "required": [
+                "input",
+                "outdir"
+            ],
             "properties": {
                 "input": {
                     "type": "string",
@@ -173,7 +176,14 @@
                     "description": "Method used to save pipeline results to output directory.",
                     "help_text": "The Nextflow `publishDir` option specifies which intermediate files should be saved to the output directory. This option tells the pipeline what method should be used to move these files. See [Nextflow docs](https://www.nextflow.io/docs/latest/process.html#publishdir) for details.",
                     "fa_icon": "fas fa-copy",
-                    "enum": ["symlink", "rellink", "link", "copy", "copyNoFollow", "move"],
+                    "enum": [
+                        "symlink",
+                        "rellink",
+                        "link",
+                        "copy",
+                        "copyNoFollow",
+                        "move"
+                    ],
                     "hidden": true
                 },
                 "email_on_fail": {
@@ -294,7 +304,10 @@
         "shortread_clipmerge_tool": {
             "type": "string",
             "default": "fastp",
-            "enum": ["fastp", "adapterremoval"]
+            "enum": [
+                "fastp",
+                "adapterremoval"
+            ]
         },
         "shortread_clipmerge_skipadaptertrim": {
             "type": "boolean"
@@ -335,7 +348,10 @@
         "shortread_complexityfilter_prinseqplusplus_mode": {
             "type": "string",
             "default": "entropy",
-            "enum": ["entropy", "dust"]
+            "enum": [
+                "entropy",
+                "dust"
+            ]
         },
         "shortread_complexityfilter_prinseqplusplus_dustscore": {
             "type": "number",
@@ -364,11 +380,20 @@
         },
         "shortread_hostremoval_reference": {
             "type": "string",
-            "default": null
+            "default": "None"
         },
         "shortread_hostremoval_index": {
             "type": "string",
-            "default": null
+            "default": "None"
+        },
+        "save_hostremoval_index": {
+            "type": "boolean"
+        },
+        "save_hostremoval_mapped": {
+            "type": "boolean"
+        },
+        "save_hostremoval_unmapped": {
+            "type": "boolean"
         }
     }
 }


### PR DESCRIPTION
## PR checklist

Closes #57

Adds options for users to save: index, mapped reads, unmapped reads (all off by default).

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
