### PR TITLE
Adds filtering out of FASTA for tools that don't support it

### DIFF
--- a/subworkflows/local/input_check.nf
+++ b/subworkflows/local/input_check.nf
@@ -45,6 +45,7 @@ def create_fastq_channel(LinkedHashMap row) {
     meta.run_accession          = row.run_accession
     meta.instrument_platform    = row.instrument_platform
     meta.single_end             = row.single_end.toBoolean()
+    meta.is_fasta               = false
 
     // add path(s) of the fastq file(s) to the meta map
     def fastq_meta = []
@@ -75,6 +76,7 @@ def create_fasta_channel(LinkedHashMap row) {
     meta.run_accession          = row.run_accession
     meta.instrument_platform    = row.instrument_platform
     meta.single_end             = true
+    meta.is_fasta               = true
 
     def array = []
     if (!file(row.fasta).exists()) {

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -76,18 +76,18 @@ workflow PROFILING {
 
     ch_input_for_centrifuge =  ch_input_for_profiling.centrifuge
                             .filter{
-                                 if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample " + it[0].id
-                                 !it[0].is_fasta
+                                if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample ${it[0].id}."
+                                !it[0].is_fasta
                             }
                             .multiMap {
                                 it ->
-                                   reads: [ it[0] + it[2], it[1] ]
-                                   db: it[3]
+                                    reads: [ it[0] + it[2], it[1] ]
+                                    db: it[3]
                             }
 
     ch_input_for_metaphlan3 = ch_input_for_profiling.metaphlan3
                             .filter{
-                                if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] MetaPhlAn3 currently does not accept FASTA files as input. Skipping MetaPhlAn3 for sample " + it[0].id
+                                if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] MetaPhlAn3 currently does not accept FASTA files as input. Skipping MetaPhlAn3 for sample ${it[0].id}."
                                 !it[0].is_fasta
                             }
                             .multiMap {

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -76,9 +76,7 @@ workflow PROFILING {
 
     ch_input_for_centrifuge =  ch_input_for_profiling.centrifuge
                             .filter{
-                                 if (it[0].is_fasta) {
-                                      WorkflowTaxprofiler.logMessage("Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample ${it[0].id}.", log)
-                                 }
+                                 if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample " + it[0].id
                                  !it[0].is_fasta
                             }
                             .multiMap {

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -87,7 +87,7 @@ workflow PROFILING {
 
     ch_input_for_metaphlan3 = ch_input_for_profiling.metaphlan3
                             .filter{
-                                if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample " + it[0].id
+                                if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] MetaPhlAn3 currently does not accept FASTA files as input. Skipping MetaPhlAn3 for sample " + it[0].id
                                 !it[0].is_fasta
                             }
                             .multiMap {

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -76,7 +76,9 @@ workflow PROFILING {
 
     ch_input_for_centrifuge =  ch_input_for_profiling.centrifuge
                             .filter{
-                                 if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample " + it[0].id
+                                 if (it[0].is_fasta) {
+                                      WorkflowTaxprofiler.logMessage("Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample ${it[0].id}.", log)
+                                 }
                                  !it[0].is_fasta
                             }
                             .multiMap {

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -76,7 +76,7 @@ workflow PROFILING {
 
     ch_input_for_centrifuge =  ch_input_for_profiling.centrifuge
                             .filter{
-                                    if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] Centrifuge does not accept FASTA files as input. Skipping Centrifuge for sample " + it[0].id
+                                    if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample " + it[0].id
                                     !it[0].is_fasta
                             }
                                 .multiMap {

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -19,7 +19,7 @@ for (param in checkPathParamList) { if (param) { file(param, checkIfExists: true
 // Check mandatory parameters
 if (params.input    ) { ch_input     = file(params.input)     } else { exit 1, 'Input samplesheet not specified!' }
 if (params.databases) { ch_databases = file(params.databases) } else { exit 1, 'Input database sheet not specified!' }
-if (params.shortread_clipmerge_mergepairs && params.run_malt ) log.warn "[nf-core/taxprofiler]: MALT does not accept uncollapsed paired-reads. Pairs will be profiled as separate files."
+if (params.shortread_clipmerge_mergepairs && params.run_malt ) log.warn "[nf-core/taxprofiler] MALT does not accept uncollapsed paired-reads. Pairs will be profiled as separate files."
 if (params.shortread_clipmerge_excludeunmerged && !params.shortread_clipmerge_mergepairs) exit 1, "ERROR: [nf-core/taxprofiler] cannot include unmerged reads when merging not turned on. Please specify --shortread_clipmerge_mergepairs"
 
 if (params.perform_shortread_hostremoval && !params.shortread_hostremoval_reference) { exit 1, "ERROR: [nf-core/taxprofiler] --shortread_hostremoval requested but no --shortread_hostremoval_reference FASTA supplied. Check input." }


### PR DESCRIPTION
## PR checklist

Closes #56

Basically if a file is marked as a 'fasta' file, will only select those which are NOT FASTA for tools such as MetaPhlAn3, and also spits out a warning that sample is being ignored.

Note a couple of things:

- Centrifuge DOES support FASTA input, but nf-core modules needs to be updated
- `.filter()` operator closure does NOT seem to support `meta, reads ->` syntax, gives some wierd error about `call()`

Also standardises warning messages

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
