### PR TITLE
Fix version reporting

### DIFF
--- a/subworkflows/local/db_check.nf
+++ b/subworkflows/local/db_check.nf
@@ -34,7 +34,7 @@ workflow DB_CHECK {
 
     emit:
     dbs = ch_final_dbs                        // channel: [ val(meta), [ db ] ]
-    versions = DATABASE_CHECK.out.versions // channel: [ versions.yml ]
+    versions = DATABASE_CHECK.out.versions.mix(UNTAR.out.versions.first()) // channel: [ versions.yml ]
 }
 
 def create_db_channels(LinkedHashMap row) {

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -129,7 +129,7 @@ workflow PROFILING {
 
         MEGAN_RMA2INFO (ch_maltrun_for_megan, params.malt_generatemegansummary )
         ch_multiqc_files   = ch_multiqc_files.mix( MALT_RUN.out.log.collect{it[1]}.ifEmpty([])  )
-        ch_versions        = ch_versions.mix( MALT_RUN.out.versions.first() )
+        ch_versions        = ch_versions.mix( MALT_RUN.out.versions.first(), MEGAN_RMA2INFO.out.versions.first() )
         ch_raw_profiles    = ch_raw_profiles.mix( MEGAN_RMA2INFO.out.txt )
     }
 

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -196,10 +196,8 @@ workflow TAXPROFILER {
         MODULE: MultiQC
     */
 
-    ch_versions    = ch_versions.mix(MULTIQC.out.versions)
-
     CUSTOM_DUMPSOFTWAREVERSIONS (
-        ch_versions.dump(tag: "software_versions_beforeuniqe").unique().dump(tag: "software_versions").collectFile(name: 'collated_versions.yml')
+        ch_versions.unique().collectFile(name: 'collated_versions.yml')
     )
 
 
@@ -236,6 +234,7 @@ workflow TAXPROFILER {
         ch_multiqc_files.collect()
     )
     multiqc_report = MULTIQC.out.report.toList()
+    ch_versions    = ch_versions.mix(MULTIQC.out.versions)
 }
 
 /*


### PR DESCRIPTION
Apparently the ordering _within_ the taxprofilering.nf script of when each versions.yml gets mixed into `ch_versions` DOES matter (against my understanding of how nextflow connects channels).

This PR moves all the `ch_versions = ch_versions.mix(<TOOL>.out.versions)` calls to _before_ CUSTOM_DUMPSOFTWAREVERSIONS, therefore they DO now get added to the `collated_versions.yml` and gets displayed in MultiQC

Note: I don't understand how this is meant to work with MultiQC, as this seems a circular argument (versions.yml gets generated by MultiQC, so needs to go into CUSTOM_DUMPSOFTWAREVERSIONS, but then MultiQC needs CUSTOM_DUMPSOFTWAREVERSIONS to execute?)

Closes #37 

<!--
# nf-core/taxprofiler pull request

Many thanks for contributing to nf-core/taxprofiler!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
