### PR TITLE
Activate institutional specific profiles

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -130,11 +130,11 @@ try {
 
 // Load nf-core/taxprofiler custom profiles from different institutions.
 // Warning: Uncomment only if a pipeline-specific instititutional config already exists on nf-core/configs!
-// try {
-//   includeConfig "${params.custom_config_base}/pipeline/taxprofiler.config"
-// } catch (Exception e) {
-//   System.err.println("WARNING: Could not load nf-core/config/taxprofiler profiles: ${params.custom_config_base}/pipeline/taxprofiler.config")
-// }
+try {
+    includeConfig "${params.custom_config_base}/pipeline/taxprofiler.config"
+} catch (Exception e) {
+    System.err.println("WARNING: Could not load nf-core/config/taxprofiler profiles: ${params.custom_config_base}/pipeline/taxprofiler.config")
+}
 
 
 profiles {


### PR DESCRIPTION
This activates the ability to use institutional-specific profiles (just uncommenting the section in `.nextflow.config`

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
