### PR TITLE
Make check_samplesheet.py compatible with nf-core/fetchngs

### DIFF
--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -37,6 +37,7 @@ def print_error(error, context="Line", context_str=""):
     print(error_str)
     sys.exit(1)
 
+
 def check_samplesheet(file_in, file_out):
     """
     This function checks that the samplesheet follows the following structure:
@@ -87,10 +88,13 @@ def check_samplesheet(file_in, file_out):
             "fasta",
         ]
         header = [x.strip('"') for x in fin.readline().strip().split(",")]
-        if header[: len(HEADER)] != HEADER:
+
+        ## Check for missing mandatory columns
+        missing_columns = list(set(HEADER) - set(header))
+        if len(missing_columns) > 0:
             print(
-                "ERROR: Please check samplesheet header -> {} != {}".format(
-                    ",".join(header), ",".join(HEADER)
+                "ERROR: Missing required column header -> {}. Note some columns can otherwise be empty. See pipeline documentation (https://nf-co.re/taxprofiler/usage).".format(
+                    ",".join(missing_columns)
                 )
             )
             sys.exit(1)
@@ -173,7 +177,9 @@ def check_samplesheet(file_in, file_out):
             ## Auto-detect paired-end/single-end
             if sample and fastq_1 and fastq_2:  ## Paired-end short reads
                 sample_info.extend(["0", fastq_1, fastq_2, fasta])
-            elif sample and fastq_1 and not fastq_2:  ## Single-end short/long fastq reads
+            elif (
+                sample and fastq_1 and not fastq_2
+            ):  ## Single-end short/long fastq reads
                 sample_info.extend(["1", fastq_1, fastq_2, fasta])
             elif (
                 sample and fasta and not fastq_1 and not fastq_2

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -100,7 +100,7 @@ def check_samplesheet(file_in, file_out):
             sys.exit(1)
 
         ## Find locations of mandatory columns
-        header_locs = dict()
+        header_locs = {}
         for i in HEADER:
             header_locs[i] = header.index(i)
 

--- a/bin/check_samplesheet.py
+++ b/bin/check_samplesheet.py
@@ -99,9 +99,17 @@ def check_samplesheet(file_in, file_out):
             )
             sys.exit(1)
 
+        ## Find locations of mandatory columns
+        header_locs = dict()
+        for i in HEADER:
+            header_locs[i] = header.index(i)
+
         ## Check sample entries
         for line in fin:
-            lspl = [x.strip().strip('"') for x in line.strip().split(",")]
+
+            ## Pull out only relevant columns for downstream checking
+            line_parsed = [x.strip().strip('"') for x in line.strip().split(",")]
+            lspl = [line_parsed[i] for i in header_locs.values()]
 
             # Check valid number of columns per row
             if len(lspl) < len(HEADER):
@@ -121,6 +129,7 @@ def check_samplesheet(file_in, file_out):
                 )
 
             ## Check sample name entries
+
             (
                 sample,
                 run_accession,


### PR DESCRIPTION
nf-core/fetchNGS produces samplesheets with many more extra metadata columns than we require, and also out of order from what we currently 'expect' during our samplesheet check.

We should make sure we check only for the mandatory columns (to allow metadata), and not necessarily require a fixed 'order' of columns. This makes it more compatible with single 'unified' samplesheets for whole projects that may want more metadata, as well as fetchngs.

This PR sees me attempting to 'do python' to meet these two criteria.

Close #89 

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
