### PR TITLE
Extract readlength from run-merged FASTQs with seqtkit

### DIFF
--- a/CITATIONS.md
+++ b/CITATIONS.md
@@ -58,6 +58,10 @@
 
 - [FILTLONG](https://github.com/rrwick/Filtlong)
 
+- [SeqKit](https://doi.org/10.1371/journal.pone.0163962.)
+
+> Shen, Wei, Shuai Le, Yan Li, and Fuquan Hu. 2016. “SeqKit: A Cross-Platform and Ultrafast Toolkit for FASTA/Q File Manipulation.” PloS One 11 (10): e0163962. doi: 10.1371/journal.pone.0163962.
+
 ## Software packaging/containerisation tools
 
 - [Anaconda](https://anaconda.com)

--- a/modules.json
+++ b/modules.json
@@ -78,6 +78,9 @@
             "samtools/view": {
                 "git_sha": "6b64f9cb6c3dd3577931cc3cd032d6fb730000ce"
             },
+            "seqkit/stats": {
+                "git_sha": "0de6406217802e0bcbef89f7568b346904f5236c"
+            },
             "untar": {
                 "git_sha": "e080f4c8acf5760039ed12ec1f206170f3f9a918"
             }

--- a/modules/local/extract_readlength.nf
+++ b/modules/local/extract_readlength.nf
@@ -1,0 +1,20 @@
+process EXTRACT_READLENGTH {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "conda-forge::bash=5.0" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://containers.biocontainers.pro/s3/SingImgsRepo/biocontainers/v1.2.0_cv2/biocontainers_v1.2.0_cv2.img' :
+        'biocontainers/biocontainers:v1.2.0_cv2' }"
+
+    input:
+    tuple val(meta), path(tsv)
+
+    output:
+    tuple val(meta), stdout, emit: read_length
+
+    script:
+    """
+    tail -n 1 $tsv | cut -f 7 | tr -d '\n'
+    """
+}

--- a/modules/nf-core/modules/seqkit/stats/main.nf
+++ b/modules/nf-core/modules/seqkit/stats/main.nf
@@ -1,0 +1,34 @@
+process SEQKIT_STATS {
+    tag "$meta.id"
+    label 'process_low'
+
+    conda (params.enable_conda ? "bioconda::seqkit=2.2.0" : null)
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/seqkit:2.2.0--h9ee0642_0':
+        'quay.io/biocontainers/seqkit:2.2.0--h9ee0642_0' }"
+
+    input:
+    tuple val(meta), path(reads)
+
+    output:
+    tuple val(meta), path("*.tsv"), emit: stats
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: '--all'
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    seqkit stats \\
+        --tabular \\
+        $args \\
+        $reads > '${prefix}.tsv'
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        seqkit: \$( seqkit version | sed 's/seqkit v//' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/modules/seqkit/stats/meta.yml
+++ b/modules/nf-core/modules/seqkit/stats/meta.yml
@@ -1,0 +1,44 @@
+name: "seqkit_stats"
+description: simple statistics of FASTA/Q files
+keywords:
+  - seqkit
+  - stats
+tools:
+  - "seqkit":
+      description: Cross-platform and ultrafast toolkit for FASTA/Q file manipulation, written by Wei Shen.
+      homepage: https://bioinf.shenwei.me/seqkit/usage/
+      documentation: https://bioinf.shenwei.me/seqkit/usage/
+      tool_dev_url: https://github.com/shenwei356/seqkit/
+      doi: "10.1371/journal.pone.0163962"
+      licence: ["MIT"]
+
+input:
+  - meta:
+      type: map
+      description: >
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - reads:
+      type: file
+      description: >
+        Either FASTA or FASTQ files.
+      pattern: "*.{fa,fna,faa,fasta,fq,fastq}[.gz]"
+
+output:
+  - meta:
+      type: map
+      description: >
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - stats:
+      type: file
+      description: >
+        Tab-separated output file with basic sequence statistics.
+      pattern: "*.tsv"
+
+authors:
+  - "@Midnighter"

--- a/nextflow.config
+++ b/nextflow.config
@@ -128,7 +128,7 @@ params {
 
 
     // bracken
-    run_bracked                = false
+    run_bracken                = false
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow.config
+++ b/nextflow.config
@@ -125,6 +125,10 @@ params {
     run_diamond                = false
     diamond_output_format      = 'tsv'  // TSV is only format with taxonomic information apparently
     diamond_save_reads         = false // this will override default diamond output format so no taxonomic profile is generated!
+
+
+    // bracken
+    run_bracked                = false
 }
 
 // Load base.config by default for all pipelines

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -435,8 +435,7 @@
             "type": "boolean"
         },
         "run_bracken": {
-            "type": "string",
-            "default": "false"
+            "type": "boolean"
         }
     }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -433,6 +433,10 @@
         },
         "diamond_save_reads": {
             "type": "boolean"
+        },
+        "run_bracken": {
+            "type": "string",
+            "default": "false"
         }
     }
 }


### PR DESCRIPTION
## PR checklist

Closes #17 but with different solution.

Note that I've dumped this within the main pipeline workflow, however likely this would make more sense in a bracken subworkflow. However this can be re-engineered by @Midnighter when he adds part of the pipeline.

I also realised this seqkit/stats might be a nice thing for us to add to MultiQC as well, as ti summarises at a more flexibile level for reporting such stats (vs fastqc/adapterremoval/fastp/filtlong etc), and is a simple TSV file so should be pretty simple to add.

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
