### PR TITLE
Add test_nothing config profile for very minimal testing

### DIFF
--- a/conf/test_nothing.config
+++ b/conf/test_nothing.config
@@ -12,7 +12,7 @@
 
 params {
     config_profile_name        = 'Test profile'
-    config_profile_description = 'Minimal test dataset without performing any profiling to check pipeline function'
+    config_profile_description = 'Minimal test dataset without performing any preprocessing nor profiling to check pipeline function. Useful when you only wish to test a single profiler without having to 'opt-out' of all the others'
 
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 2

--- a/conf/test_nothing.config
+++ b/conf/test_nothing.config
@@ -1,0 +1,47 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/taxprofiler -profile test,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+params {
+    config_profile_name        = 'Test profile'
+    config_profile_description = 'Minimal test dataset without performing any profiling to check pipeline function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = '6.GB'
+    max_time   = '6.h'
+
+    // Input data
+    // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
+    // TODO nf-core: Give any required params for the test so that command line flags are not needed
+    input                                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/taxprofiler/samplesheet.csv'
+    databases                             = 'https://raw.githubusercontent.com/nf-core/test-datasets/taxprofiler/database.csv'
+    perform_shortread_qc                  = false
+    perform_longread_qc                   = false
+    perform_shortread_complexityfilter    = false
+    perform_shortread_hostremoval         = false
+    perform_longread_hostremoval          = false
+    perform_runmerging                    = false
+    hostremoval_reference                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                             = false
+    run_kraken2                           = false
+    run_malt                              = false
+    run_metaphlan3                        = false
+    run_centrifuge                        = false
+    run_diamond                           = false
+    run_motus                             = false
+}
+
+process {
+    withName: MALT_RUN {
+        maxForks = 1
+    }
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -204,11 +204,12 @@ profiles {
         podman.enabled         = false
         shifter.enabled        = false
     }
-    test      { includeConfig 'conf/test.config'      }
-    test_full { includeConfig 'conf/test_full.config' }
-    test_noprofiling { includeConfig 'conf/test_noprofiling.config' }
-    test_nopreprocessing { includeConfig 'conf/test_nopreprocessing.config' }
-    test_motus { includeConfig 'conf/test_motus.config' }
+    test                    { includeConfig 'conf/test.config'      }
+    test_full               { includeConfig 'conf/test_full.config' }
+    test_noprofiling        { includeConfig 'conf/test_noprofiling.config' }
+    test_nopreprocessing    { includeConfig 'conf/test_nopreprocessing.config' }
+    test_nothing            { includeConfig 'conf/test_nothing.config' }
+    test_motus              { includeConfig 'conf/test_motus.config' }
 }
 
 // Load igenomes.config if required


### PR DESCRIPTION
As testing each profiler can take a very long time using a profile that runs ALL the tools (and we are following an 'opt out' scheme in the tests, this adds a tiny test profile that runs literally nothing except samplesheetchecl/untarfastqc/multiqc (so no preprocessing nor profiling) this way you can just turn on whatever you want to test with during testing.

This is only really for devs so not necessary to adddocs.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
  - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
  - [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [x] `README.md` is updated (including new tool citations and authors/contributors).
