### PR TITLE
Improve longread QC parameters

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -136,9 +136,9 @@ process {
 
     withName: FILTLONG {
         ext.args = [
-            "--min_length ${params.longread_qc_minlength}",
-            "--keep_percent ${params.longread_qc_keep_percent}",
-            "--target_bases ${params.longread_qc_target_bases}"
+            "--min_length ${params.longread_qc_qualityfilter_minlength}",
+            "--keep_percent ${params.longread_qc_qualityfilter_keeppercent}",
+            "--target_bases ${params.longread_qc_qualityfilter_targetbases}"
         ]
         .join(' ').trim()
         ext.prefix = { "${meta.id}_${meta.run_accession}_filtered" }

--- a/conf/test.config
+++ b/conf/test.config
@@ -27,8 +27,6 @@ params {
     perform_shortread_qc                  = true
     perform_longread_qc                   = true
     shortread_qc_mergepairs               = true
-    longread_qc_skipadaptertrim           = false
-    longread_qc_qualityfilter             = true
     perform_shortread_complexityfilter    = true
     perform_shortread_hostremoval         = true
     perform_longread_hostremoval          = true

--- a/conf/test.config
+++ b/conf/test.config
@@ -26,6 +26,9 @@ params {
     databases                             = 'https://raw.githubusercontent.com/nf-core/test-datasets/taxprofiler/database.csv'
     perform_shortread_qc                  = true
     perform_longread_qc                   = true
+    shortread_qc_mergepairs               = true
+    longread_qc_skipadaptertrim           = false
+    longread_qc_qualityfilter             = true
     perform_shortread_complexityfilter    = true
     perform_shortread_hostremoval         = true
     perform_longread_hostremoval          = true

--- a/conf/test_noprofiling.config
+++ b/conf/test_noprofiling.config
@@ -27,8 +27,6 @@ params {
     perform_shortread_qc                  = true
     perform_longread_qc                   = true
     shortread_qc_mergepairs               = true
-    longread_qc_skipadaptertrim           = false
-    longread_qc_qualityfilter             = true
     perform_shortread_complexityfilter    = true
     perform_shortread_hostremoval         = true
     perform_longread_hostremoval          = true

--- a/conf/test_noprofiling.config
+++ b/conf/test_noprofiling.config
@@ -26,6 +26,9 @@ params {
     databases                             = 'https://raw.githubusercontent.com/nf-core/test-datasets/taxprofiler/database.csv'
     perform_shortread_qc                  = true
     perform_longread_qc                   = true
+    shortread_qc_mergepairs               = true
+    longread_qc_skipadaptertrim           = false
+    longread_qc_qualityfilter             = true
     perform_shortread_complexityfilter    = true
     perform_shortread_hostremoval         = true
     perform_longread_hostremoval          = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -62,7 +62,7 @@ params {
     shortread_qc_excludeunmerged     = false
     shortread_qc_adapter1            = null
     shortread_qc_adapter2            = null
-    shortread_qc_minlength           = 15
+    shortread_qc_minlength           = 0
 
     perform_longread_qc                   = false
     longread_qc_skipadaptertrim           = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,7 +66,7 @@ params {
 
     perform_longread_qc                   = false
     longread_qc_skipadaptertrim           = false
-    longread_qc_skipqualityfilter         = true
+    longread_qc_skipqualityfilter         = false
     longread_qc_qualityfilter_minlength   = 1000
     longread_qc_qualityfilter_keeppercent = 90
     longread_qc_qualityfilter_targetbases = 500000000

--- a/nextflow.config
+++ b/nextflow.config
@@ -66,7 +66,7 @@ params {
 
     perform_longread_qc                   = false
     longread_qc_skipadaptertrim           = false
-    longread_qc_qualityfilter             = true
+    longread_qc_skipqualityfilter         = true
     longread_qc_qualityfilter_minlength   = 1000
     longread_qc_qualityfilter_keeppercent = 90
     longread_qc_qualityfilter_targetbases = 500000000

--- a/nextflow.config
+++ b/nextflow.config
@@ -58,15 +58,15 @@ params {
     perform_shortread_qc             = false
     shortread_qc_tool                = 'fastp'
     shortread_qc_skipadaptertrim     = false
-    shortread_qc_mergepairs          = false
+    shortread_qc_mergepairs          = true
     shortread_qc_excludeunmerged     = false
     shortread_qc_adapter1            = null
     shortread_qc_adapter2            = null
-    shortread_qc_minlength           = 0
+    shortread_qc_minlength           = 15
 
     perform_longread_qc                   = false
     longread_qc_skipadaptertrim           = false
-    longread_qc_qualityfilter             = false
+    longread_qc_qualityfilter             = true
     longread_qc_qualityfilter_minlength   = 1000
     longread_qc_qualityfilter_keeppercent = 90
     longread_qc_qualityfilter_targetbases = 500000000

--- a/nextflow.config
+++ b/nextflow.config
@@ -64,12 +64,12 @@ params {
     shortread_qc_adapter2            = null
     shortread_qc_minlength           = 15
 
-    perform_longread_qc              = false
-    longread_qc_run_clip             = false
-    longread_qc_run_filter           = false
-    longread_qc_minlength            = 1000
-    longread_qc_keep_percent        = 90
-    longread_qc_target_bases         = 500000000
+    perform_longread_qc                   = false
+    longread_qc_skipadaptertrim           = false
+    longread_qc_qualityfilter             = false
+    longread_qc_qualityfilter_minlength   = 1000
+    longread_qc_qualityfilter_keeppercent = 90
+    longread_qc_qualityfilter_targetbases = 500000000
 
     save_preprocessed_reads          = false
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -407,18 +407,18 @@
         "longread_qc_skipadaptertrim": {
             "type": "boolean"
         },
-        "longread_qc_qualityfilter": {
+        "longread_qc_skipqualityfilter": {
             "type": "boolean"
         },
-        "longread_qc_qualityfilter_minlength": {
+        "longread_qc_skipqualityfilter_minlength": {
             "type": "integer",
             "default": 1000
         },
-        "longread_qc_qualityfilter_keeppercent": {
+        "longread_qc_skipqualityfilter_keeppercent": {
             "type": "integer",
             "default": 90
         },
-        "longread_qc_qualityfilter_targetbases": {
+        "longread_qc_skipqualityfilter_targetbases": {
             "type": "integer",
             "default": 500000000
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -410,15 +410,15 @@
         "longread_qc_skipqualityfilter": {
             "type": "boolean"
         },
-        "longread_qc_skipqualityfilter_minlength": {
+        "longread_qc_qualityfilter_minlength": {
             "type": "integer",
             "default": 1000
         },
-        "longread_qc_skipqualityfilter_keeppercent": {
+        "longread_qc_qualityfilter_keeppercent": {
             "type": "integer",
             "default": 90
         },
-        "longread_qc_skipqualityfilter_targetbases": {
+        "longread_qc_qualityfilter_targetbases": {
             "type": "integer",
             "default": 500000000
         },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -404,21 +404,21 @@
             "type": "integer",
             "default": 30
         },
-        "longread_qc_run_clip": {
+        "longread_qc_skipadaptertrim": {
             "type": "boolean"
         },
-        "longread_qc_run_filter": {
+        "longread_qc_qualityfilter": {
             "type": "boolean"
         },
-        "longread_qc_minlength": {
+        "longread_qc_qualityfilter_minlength": {
             "type": "integer",
             "default": 1000
         },
-        "longread_qc_keep_percent": {
+        "longread_qc_qualityfilter_keeppercent": {
             "type": "integer",
             "default": 90
         },
-        "longread_qc_target_bases": {
+        "longread_qc_qualityfilter_targetbases": {
             "type": "integer",
             "default": 500000000
         },

--- a/subworkflows/local/longread_preprocessing.nf
+++ b/subworkflows/local/longread_preprocessing.nf
@@ -14,7 +14,7 @@ workflow LONGREAD_PREPROCESSING {
     ch_versions      = Channel.empty()
     ch_multiqc_files = Channel.empty()
 
-    if ( params.longread_qc_run_clip && !params.longread_qc_run_filter ) {
+    if ( !params.longread_qc_skipadaptertrim && !params.longread_qc_qualityfilter ) {
         PORECHOP ( reads )
 
         ch_processed_reads = PORECHOP.out.reads
@@ -28,7 +28,7 @@ workflow LONGREAD_PREPROCESSING {
         ch_versions = ch_versions.mix(PORECHOP.out.versions.first())
         ch_multiqc_files = ch_multiqc_files.mix( PORECHOP.out.log )
 
-    } else if ( !params.longread_qc_run_clip && params.longread_qc_run_filter ) {
+    } else if ( params.longread_qc_skipadaptertrim && params.longread_qc_qualityfilter ) {
 
         ch_processed_reads = FILTLONG ( reads.map{ meta, reads -> [meta, [], reads ]} )
         ch_versions = ch_versions.mix(FILTLONG.out.versions.first())

--- a/subworkflows/local/longread_preprocessing.nf
+++ b/subworkflows/local/longread_preprocessing.nf
@@ -14,7 +14,7 @@ workflow LONGREAD_PREPROCESSING {
     ch_versions      = Channel.empty()
     ch_multiqc_files = Channel.empty()
 
-    if ( !params.longread_qc_skipadaptertrim && !params.longread_qc_qualityfilter ) {
+    if ( !params.longread_qc_skipadaptertrim && params.longread_qc_skipqualityfilter) {
         PORECHOP ( reads )
 
         ch_processed_reads = PORECHOP.out.reads
@@ -28,7 +28,7 @@ workflow LONGREAD_PREPROCESSING {
         ch_versions = ch_versions.mix(PORECHOP.out.versions.first())
         ch_multiqc_files = ch_multiqc_files.mix( PORECHOP.out.log )
 
-    } else if ( params.longread_qc_skipadaptertrim && params.longread_qc_qualityfilter ) {
+    } else if ( params.longread_qc_skipadaptertrim && !params.longread_qc_skipqualityfilter) {
 
         ch_processed_reads = FILTLONG ( reads.map{ meta, reads -> [meta, [], reads ]} )
         ch_versions = ch_versions.mix(FILTLONG.out.versions.first())

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -22,7 +22,6 @@ if (params.databases) { ch_databases = file(params.databases) } else { exit 1, '
 
 if (params.shortread_qc_mergepairs && params.run_malt ) log.warn "[nf-core/taxprofiler] MALT does not accept uncollapsed paired-reads. Pairs will be profiled as separate files."
 if (params.shortread_qc_excludeunmerged && !params.shortread_qc_mergepairs) exit 1, "ERROR: [nf-core/taxprofiler] cannot include unmerged reads when merging not turned on. Please specify --shortread_qc_mergepairs"
-if ( (!params.longread_qc_skipadaptertrim || !params.longread_qc_skipqualityfilter) & !params.perform_longread_qc ) exit 1, "ERROR: [nf-core/taxprofiler] --longread_qc_skipadaptertrim false or --longread_qc_skipqualityfilter requested but quality-control not turned on. Please specify --perform_long_qc"
 
 if (params.shortread_complexityfilter_tool == 'fastp' && ( params.perform_shortread_qc == false || params.shortread_qc_tool != 'fastp' ))  exit 1, "ERROR: [nf-core/taxprofiler] cannot use fastp complexity filtering if preprocessing not turned on and/or tool is not fastp. Please specify --perform_shortread_qc and/or --shortread_qc_tool 'fastp'"
 

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -22,7 +22,7 @@ if (params.databases) { ch_databases = file(params.databases) } else { exit 1, '
 
 if (params.shortread_qc_mergepairs && params.run_malt ) log.warn "[nf-core/taxprofiler] MALT does not accept uncollapsed paired-reads. Pairs will be profiled as separate files."
 if (params.shortread_qc_excludeunmerged && !params.shortread_qc_mergepairs) exit 1, "ERROR: [nf-core/taxprofiler] cannot include unmerged reads when merging not turned on. Please specify --shortread_qc_mergepairs"
-if ( (!params.longread_qc_skipadaptertrim || !params.longread_qc_skipqualityfilter) & !params.perform_longread_qc ) exit 1, "ERROR: [nf-core/taxprofiler] --longread_qc_skipadaptertrim false or --longread_qc_skipqualityfilterrequested but quality-control not turned on. Please specify --perform_long_qc"
+if ( (!params.longread_qc_skipadaptertrim || !params.longread_qc_skipqualityfilter) & !params.perform_longread_qc ) exit 1, "ERROR: [nf-core/taxprofiler] --longread_qc_skipadaptertrim false or --longread_qc_skipqualityfilter requested but quality-control not turned on. Please specify --perform_long_qc"
 
 if (params.shortread_complexityfilter_tool == 'fastp' && ( params.perform_shortread_qc == false || params.shortread_qc_tool != 'fastp' ))  exit 1, "ERROR: [nf-core/taxprofiler] cannot use fastp complexity filtering if preprocessing not turned on and/or tool is not fastp. Please specify --perform_shortread_qc and/or --shortread_qc_tool 'fastp'"
 

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -22,7 +22,7 @@ if (params.databases) { ch_databases = file(params.databases) } else { exit 1, '
 
 if (params.shortread_qc_mergepairs && params.run_malt ) log.warn "[nf-core/taxprofiler] MALT does not accept uncollapsed paired-reads. Pairs will be profiled as separate files."
 if (params.shortread_qc_excludeunmerged && !params.shortread_qc_mergepairs) exit 1, "ERROR: [nf-core/taxprofiler] cannot include unmerged reads when merging not turned on. Please specify --shortread_qc_mergepairs"
-if ( (params.longread_qc_run_clip || params.longread_qc_run_filter) & !params.perform_longread_qc ) exit 1, "ERROR: [nf-core/taxprofiler] --longread_qc_run_clip or --longread_qc_run_filter requested but quality-control not turned on. Please specify --perform_long_qc"
+if ( (!params.longread_qc_skipadaptertrim || params.longread_qc_qualityfilter) & !params.perform_longread_qc ) exit 1, "ERROR: [nf-core/taxprofiler] --longread_qc_skipadaptertrim false or --longread_qc_qualityfilter requested but quality-control not turned on. Please specify --perform_long_qc"
 
 if (params.shortread_complexityfilter_tool == 'fastp' && ( params.perform_shortread_qc == false || params.shortread_qc_tool != 'fastp' ))  exit 1, "ERROR: [nf-core/taxprofiler] cannot use fastp complexity filtering if preprocessing not turned on and/or tool is not fastp. Please specify --perform_shortread_qc and/or --shortread_qc_tool 'fastp'"
 

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -22,7 +22,7 @@ if (params.databases) { ch_databases = file(params.databases) } else { exit 1, '
 
 if (params.shortread_qc_mergepairs && params.run_malt ) log.warn "[nf-core/taxprofiler] MALT does not accept uncollapsed paired-reads. Pairs will be profiled as separate files."
 if (params.shortread_qc_excludeunmerged && !params.shortread_qc_mergepairs) exit 1, "ERROR: [nf-core/taxprofiler] cannot include unmerged reads when merging not turned on. Please specify --shortread_qc_mergepairs"
-if ( (!params.longread_qc_skipadaptertrim || params.longread_qc_qualityfilter) & !params.perform_longread_qc ) exit 1, "ERROR: [nf-core/taxprofiler] --longread_qc_skipadaptertrim false or --longread_qc_qualityfilter requested but quality-control not turned on. Please specify --perform_long_qc"
+if ( (!params.longread_qc_skipadaptertrim || !params.longread_qc_skipqualityfilter) & !params.perform_longread_qc ) exit 1, "ERROR: [nf-core/taxprofiler] --longread_qc_skipadaptertrim false or --longread_qc_skipqualityfilterrequested but quality-control not turned on. Please specify --perform_long_qc"
 
 if (params.shortread_complexityfilter_tool == 'fastp' && ( params.perform_shortread_qc == false || params.shortread_qc_tool != 'fastp' ))  exit 1, "ERROR: [nf-core/taxprofiler] cannot use fastp complexity filtering if preprocessing not turned on and/or tool is not fastp. Please specify --perform_shortread_qc and/or --shortread_qc_tool 'fastp'"
 


### PR DESCRIPTION
As reported by @sofstam in person, we had an issue where `Filtlong` was not being executed in our tests profile.

When I went to investigate, I realised this was because the longread parameters worked differently to the shortread_qc parameters (but with the same defaults).

This PR homogenises the structure by updating the parameter names and defaults so they follow the same 'behaviour'.

The default behaviour is now to run ALL clipping, merging, and filtering _if_ shortread QC is turned on.