### PR TITLE
Fix mOTUs CI and old param warn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,9 +64,6 @@ jobs:
     name: Test mOTUs with workflow parameters
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/taxprofiler') }}
     runs-on: ubuntu-latest
-    env:
-      NXF_VER: ${{ matrix.nxf_ver }}
-      NXF_ANSI_LOG: false
     strategy:
       matrix:
         NXF_VER:

--- a/conf/test_motus.config
+++ b/conf/test_motus.config
@@ -24,8 +24,8 @@ params {
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
     input                                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/taxprofiler/samplesheet.csv'
     databases                             = 'database_motus.csv'
-    perform_shortread_clipmerge           = false
-    perform_longread_clip                 = false
+    perform_shortread_qc                  = false
+    perform_longread_qc                   = false
     perform_shortread_complexityfilter    = false
     perform_shortread_hostremoval         = false
     perform_longread_hostremoval          = false


### PR DESCRIPTION
Left over from #117 as I suddenly remembered why the CI tests were failing, and also clean up another little thing I noticed in the mOTUs test

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
