### PR TITLE
Kaiju2table move

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -268,7 +268,7 @@ process {
         // one run with multiple samples, so fix ID to just db name to ensure clean log name
         ext.prefix = { "${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/malt/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/malt/${meta.db_name}/" },
             mode: params.publish_dir_mode,
             pattern: '*.{rma6,log,sam}'
         ]
@@ -278,7 +278,7 @@ process {
         ext.args = "-c2c Taxonomy"
         ext.prefix = { "${meta.id}" }
         publishDir = [
-            path: { "${params.outdir}/malt/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/malt/${meta.db_name}/" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt.gz,megan}'
         ]
@@ -288,7 +288,7 @@ process {
         ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/kraken2/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/kraken2/${meta.db_name}/" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt,report,fastq.gz}'
         ]
@@ -297,7 +297,7 @@ process {
     withName: KRONA_CLEANUP {
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/krona/${ext.prefix}" },
+            path: { "${params.outdir}/krona/" },
             mode: params.publish_dir_mode,
             pattern: '*.{html}'
         ]
@@ -306,7 +306,7 @@ process {
     withName: KRONA_KTIMPORTTEXT {
         ext.prefix = { "${meta.tool}-${meta.id}" }
         publishDir = [
-            path: { "${params.outdir}/krona/${ext.prefix}" },
+            path: { "${params.outdir}/krona/" },
             mode: params.publish_dir_mode,
             pattern: '*.{html}'
         ]
@@ -321,7 +321,7 @@ process {
         ext.args = "-i"
         ext.prefix = { "${meta.tool}-${meta.id}" }
         publishDir = [
-            path: { "${params.outdir}/krona/${ext.prefix}" },
+            path: { "${params.outdir}/krona/" },
             mode: params.publish_dir_mode,
             pattern: '*.{html}'
         ]
@@ -331,7 +331,7 @@ process {
         ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/metaphlan3/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/metaphlan3/${meta.db_name}/" },
             mode: params.publish_dir_mode,
             pattern: '*.{biom,txt}'
         ]
@@ -339,7 +339,7 @@ process {
 
     withName: CENTRIFUGE_CENTRIFUGE {
         publishDir = [
-            path: { "${params.outdir}/centrifuge/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/centrifuge/${meta.db_name}/" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt,sam,gz}'
         ]
@@ -352,7 +352,7 @@ process {
         ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.centrifuge" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.centrifuge" }
         publishDir = [
-            path: { "${params.outdir}/centrifuge/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/centrifuge/${meta.db_name}/" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt}'
         ]
@@ -361,7 +361,7 @@ process {
     withName: KAIJU_KAIJU {
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/kaiju/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/kaiju/${meta.db_name}/" },
             mode: params.publish_dir_mode,
             pattern: '*.tsv'
         ]
@@ -385,7 +385,7 @@ process {
         ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/diamond/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/diamond/${meta.db_name}/" },
             mode: params.publish_dir_mode,
             pattern: '*.{blast,xml,txt,daa,sam,tsv,paf,log}'
         ]
@@ -394,7 +394,7 @@ process {
     withName: MOTUS_PROFILE {
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/motus/${meta.db_name}/${ext.prefix}" },
+            path: { "${params.outdir}/motus/${meta.db_name}/" },
             mode: params.publish_dir_mode
         ]
     }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -268,7 +268,7 @@ process {
         // one run with multiple samples, so fix ID to just db name to ensure clean log name
         ext.prefix = { "${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/malt/${meta.db_name}" },
+            path: { "${params.outdir}/malt/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{rma6,log,sam}'
         ]
@@ -278,7 +278,7 @@ process {
         ext.args = "-c2c Taxonomy"
         ext.prefix = { "${meta.id}" }
         publishDir = [
-            path: { "${params.outdir}/malt/${meta.db_name}" },
+            path: { "${params.outdir}/malt/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt.gz,megan}'
         ]
@@ -288,7 +288,7 @@ process {
         ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/kraken2/${meta.db_name}" },
+            path: { "${params.outdir}/kraken2/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt,report,fastq.gz}'
         ]
@@ -297,7 +297,7 @@ process {
     withName: KRONA_CLEANUP {
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/krona" },
+            path: { "${params.outdir}/krona/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{html}'
         ]
@@ -306,7 +306,7 @@ process {
     withName: KRONA_KTIMPORTTEXT {
         ext.prefix = { "${meta.tool}-${meta.id}" }
         publishDir = [
-            path: { "${params.outdir}/krona" },
+            path: { "${params.outdir}/krona/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{html}'
         ]
@@ -321,7 +321,7 @@ process {
         ext.args = "-i"
         ext.prefix = { "${meta.tool}-${meta.id}" }
         publishDir = [
-            path: { "${params.outdir}/krona" },
+            path: { "${params.outdir}/krona/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{html}'
         ]
@@ -331,7 +331,7 @@ process {
         ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/metaphlan3/${meta.db_name}" },
+            path: { "${params.outdir}/metaphlan3/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{biom,txt}'
         ]
@@ -339,7 +339,7 @@ process {
 
     withName: CENTRIFUGE_CENTRIFUGE {
         publishDir = [
-            path: { "${params.outdir}/centrifuge/${meta.db_name}" },
+            path: { "${params.outdir}/centrifuge/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt,sam,gz}'
         ]
@@ -352,27 +352,26 @@ process {
         ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.centrifuge" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.centrifuge" }
         publishDir = [
-            path: { "${params.outdir}/centrifuge/${meta.db_name}" },
+            path: { "${params.outdir}/centrifuge/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt}'
         ]
     }
 
     withName: KAIJU_KAIJU {
+        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/kaiju/${meta.db_name}" },
+            path: { "${params.outdir}/kaiju/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.tsv'
         ]
         ext.args = { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
     }
 
     withName: KAIJU_KAIJU2TABLE {
-        ext.args = { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
+        ext.prefix = { "${meta.id}_combined_reports" }
         publishDir = [
-            path: { "${params.outdir}/kaiju/${meta.db_name}" },
+            path: { "${params.outdir}/kaiju/" },
             mode: params.publish_dir_mode,
             pattern: '*.{txt}'
         ]
@@ -386,7 +385,7 @@ process {
         ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/diamond/${meta.db_name}" },
+            path: { "${params.outdir}/diamond/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode,
             pattern: '*.{blast,xml,txt,daa,sam,tsv,paf,log}'
         ]
@@ -395,7 +394,7 @@ process {
     withName: MOTUS_PROFILE {
         ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
         publishDir = [
-            path: { "${params.outdir}/motus/${meta.db_name}" },
+            path: { "${params.outdir}/motus/${meta.db_name}/${ext.prefix}" },
             mode: params.publish_dir_mode
         ]
     }

--- a/conf/test_nothing.config
+++ b/conf/test_nothing.config
@@ -12,7 +12,7 @@
 
 params {
     config_profile_name        = 'Test profile'
-    config_profile_description = 'Minimal test dataset without performing any preprocessing nor profiling to check pipeline function. Useful when you only wish to test a single profiler without having to 'opt-out' of all the others'
+    config_profile_description = 'Minimal test dataset without performing any preprocessing nor profiling to check pipeline function. Useful when you only wish to test a single profiler without having to opt-out of all the others'
 
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 2

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -9,7 +9,6 @@ include { CENTRIFUGE_CENTRIFUGE                 } from '../../modules/nf-core/mo
 include { CENTRIFUGE_KREPORT                    } from '../../modules/nf-core/modules/centrifuge/kreport/main'
 include { METAPHLAN3                            } from '../../modules/nf-core/modules/metaphlan3/main'
 include { KAIJU_KAIJU                           } from '../../modules/nf-core/modules/kaiju/kaiju/main'
-include { KAIJU_KAIJU2TABLE                     } from '../../modules/nf-core/modules/kaiju/kaiju2table/main'
 include { DIAMOND_BLASTX                        } from '../../modules/nf-core/modules/diamond/blastx/main'
 include { MOTUS_PROFILE                         } from '../../modules/nf-core/modules/motus/profile/main'
 
@@ -185,11 +184,8 @@ workflow PROFILING {
                             }
 
         KAIJU_KAIJU ( ch_input_for_kaiju.reads, ch_input_for_kaiju.db)
-        KAIJU_KAIJU2TABLE (KAIJU_KAIJU.out.results, ch_input_for_kaiju.db, params.kaiju_taxon_rank)
-        ch_multiqc_files = ch_multiqc_files.mix( KAIJU_KAIJU2TABLE.out.summary )
         ch_versions = ch_versions.mix( KAIJU_KAIJU.out.versions.first() )
         ch_raw_classifications = ch_raw_classifications.mix( KAIJU_KAIJU.out.results )
-        ch_raw_profiles = ch_raw_profiles.mix( KAIJU_KAIJU2TABLE.out.summary )
 
     }
 

--- a/subworkflows/local/standardisation_profiles.nf
+++ b/subworkflows/local/standardisation_profiles.nf
@@ -1,7 +1,8 @@
 //
-// Create Krona visualizations
+// Standardise output files e.g. aggregation
 //
 
+include { KAIJU_KAIJU2TABLE                     } from '../../modules/nf-core/modules/kaiju/kaiju2table/main'
 include { MOTUS_MERGE } from '../../modules/nf-core/modules/motus/merge/main'
 
 workflow STANDARDISATION_PROFILES {
@@ -14,6 +15,7 @@ workflow STANDARDISATION_PROFILES {
     main:
     ch_standardised_tables = Channel.empty()
     ch_versions            = Channel.empty()
+    ch_multiqc_files       = Channel.empty()
 
     /*
         Split profile results based on tool they come from
@@ -26,18 +28,35 @@ workflow STANDARDISATION_PROFILES {
 
     ch_input_classifications = classifications
         .branch {
+            kaiju: it[0]['tool'] == 'kaiju'
             unknown: true
         }
 
     ch_input_databases = databases
         .branch {
             motus: it[0]['tool'] == 'motus'
+            kaiju: it[0]['tool'] == 'kaiju'
             unknown: true
         }
 
     /*
         Standardise and aggregate
     */
+
+    // Kaiju
+
+    // Collect and replace id for db_name for prefix
+    ch_profiles_for_kaiju = ch_input_classifications.kaiju
+                                .map { [it[0]['db_name'], it[1]] }
+                                .groupTuple()
+                                .map {
+                                    [[id:it[0]], it[1]]
+                                }
+
+    KAIJU_KAIJU2TABLE ( ch_profiles_for_kaiju, ch_input_databases.kaiju.map{it[1]}, params.kaiju_taxon_rank)
+    ch_standardised_tables = ch_standardised_tables.mix( KAIJU_KAIJU2TABLE.out.summary )
+    ch_multiqc_files = ch_multiqc_files.mix( KAIJU_KAIJU2TABLE.out.summary )
+    ch_versions = ch_versions.mix( KAIJU_KAIJU2TABLE.out.versions )
 
     // mOTUs has a 'single' database, and cannot create custom ones.
     // Therefore removing db info here, and publish merged at root mOTUs results
@@ -51,6 +70,7 @@ workflow STANDARDISATION_PROFILES {
     ch_versions = ch_versions.mix( MOTUS_MERGE.out.versions )
 
     emit:
-    tables = ch_standardised_tables
+    tables   = ch_standardised_tables
     versions = ch_versions
+    mqc      = ch_multiqc_files
 }

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -271,8 +271,6 @@ workflow TAXPROFILER {
         ch_multiqc_files = ch_multiqc_files.mix( STANDARDISATION_PROFILES.out.mqc.collect{it[1]}.ifEmpty([]) )
     }
 
-    ch_multiqc_files = ch_multiqc_files.mix( PROFILING.out.mqc.collect{it[1]}.ifEmpty([]) )
-
     // TODO create multiQC module for metaphlan
     MULTIQC (
         ch_multiqc_files.collect()

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -267,6 +267,12 @@ workflow TAXPROFILER {
 
     ch_multiqc_files = ch_multiqc_files.mix( PROFILING.out.mqc.collect{it[1]}.ifEmpty([]) )
 
+    if ( params.run_profile_standardisation ) {
+        ch_multiqc_files = ch_multiqc_files.mix( STANDARDISATION_PROFILES.out.mqc.collect{it[1]}.ifEmpty([]) )
+    }
+
+    ch_multiqc_files = ch_multiqc_files.mix( PROFILING.out.mqc.collect{it[1]}.ifEmpty([]) )
+
     // TODO create multiQC module for metaphlan
     MULTIQC (
         ch_multiqc_files.collect()


### PR DESCRIPTION
Use Kaiju2table properly by moving to mOTUs merge subworkflow, and 

I also use the same PR to restructure the output slightly so we will have a structure such as:

```
results/tool/db1/sample_1_db1.txt
results/tool/db1/sample_2_db1.txt
results/tool/db2/sample_1_db2.txt
results/tool/db2/sample_2_db2.txt
results/tool/db1_combined.tsv
results/tool/db2_combined.tsv
````

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
