### PR TITLE
Include the mapped reads in samtools stats

### DIFF
--- a/subworkflows/local/longread_hostremoval.nf
+++ b/subworkflows/local/longread_hostremoval.nf
@@ -45,7 +45,7 @@ workflow LONGREAD_HOSTREMOVAL {
     ch_versions      = ch_versions.mix( SAMTOOLS_INDEX.out.versions.first() )
 
     bam_bai = MINIMAP2_ALIGN.out.bam
-        .join(SAMTOOLS_INDEX.out.bai,by:[0], remainder: true)
+        .join(SAMTOOLS_INDEX.out.bai, remainder: true)
 
     SAMTOOLS_STATS ( bam_bai, reference )
     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())

--- a/subworkflows/local/longread_hostremoval.nf
+++ b/subworkflows/local/longread_hostremoval.nf
@@ -44,8 +44,8 @@ workflow LONGREAD_HOSTREMOVAL {
     SAMTOOLS_INDEX ( SAMTOOLS_VIEW.out.bam )
     ch_versions      = ch_versions.mix( SAMTOOLS_INDEX.out.versions.first() )
 
-    bam_bai = SAMTOOLS_VIEW.out.bam
-        .join(SAMTOOLS_INDEX.out.bai, remainder: true)
+    bam_bai = MINIMAP2_ALIGN.out.bam
+        .join(SAMTOOLS_INDEX.out.bai,by:[0], remainder: true)
 
     SAMTOOLS_STATS ( bam_bai, reference )
     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())

--- a/subworkflows/local/shortread_hostremoval.nf
+++ b/subworkflows/local/shortread_hostremoval.nf
@@ -42,7 +42,7 @@ workflow SHORTREAD_HOSTREMOVAL {
     ch_versions      = ch_versions.mix( SAMTOOLS_INDEX.out.versions.first() )
 
     bam_bai = BOWTIE2_ALIGN.out.bam
-        .join(SAMTOOLS_INDEX.out.bai, by:[0], remainder: true)
+        .join(SAMTOOLS_INDEX.out.bai, remainder: true)
 
     SAMTOOLS_STATS ( bam_bai, reference )
     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())

--- a/subworkflows/local/shortread_hostremoval.nf
+++ b/subworkflows/local/shortread_hostremoval.nf
@@ -25,7 +25,7 @@ workflow SHORTREAD_HOSTREMOVAL {
         ch_bowtie2_index = index.first()
     }
 
-    BOWTIE2_ALIGN ( reads, ch_bowtie2_index, true, false )
+    BOWTIE2_ALIGN ( reads, ch_bowtie2_index, true, true)
     ch_versions      = ch_versions.mix( BOWTIE2_ALIGN.out.versions.first() )
     ch_multiqc_files = ch_multiqc_files.mix( BOWTIE2_ALIGN.out.log )
 
@@ -41,8 +41,8 @@ workflow SHORTREAD_HOSTREMOVAL {
     SAMTOOLS_INDEX ( SAMTOOLS_VIEW.out.bam )
     ch_versions      = ch_versions.mix( SAMTOOLS_INDEX.out.versions.first() )
 
-    bam_bai = SAMTOOLS_VIEW.out.bam
-        .join(SAMTOOLS_INDEX.out.bai, remainder: true)
+    bam_bai = BOWTIE2_ALIGN.out.bam
+        .join(SAMTOOLS_INDEX.out.bai, by:[0], remainder: true)
 
     SAMTOOLS_STATS ( bam_bai, reference )
     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())


### PR DESCRIPTION
This PR updates the #161 and #162.Before only the unmapped reads were shown in the samtools stats. It includes the mapped reads as well.

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
