### PR TITLE
Separate KrakenUniq test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,36 @@ jobs:
         with:
           command: nextflow run ${GITHUB_WORKSPACE} -profile test_motus,docker --outdir ./results --databases ./database_motus.csv
           attempt_limit: 3
+
+  krakenuniq:
+    name: Test mOTUs with workflow parameters
+    if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/taxprofiler') }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        NXF_VER:
+          - "21.10.3"
+          - "latest-everything"
+
+    steps:
+      - name: Check out pipeline code
+        uses: actions/checkout@v2
+
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v1
+        with:
+          version: "${{ matrix.NXF_VER }}"
+
+      - name: Show current locale
+        run: locale
+
+      - name: Set UTF-8 enabled locale
+        run: |
+          sudo locale-gen en_US.UTF-8
+          sudo update-locale LANG=en_US.UTF-8
+
+      - name: Run pipeline with test data
+        uses: Wandalen/wretry.action@v1.0.11
+        with:
+          command: nextflow run ${GITHUB_WORKSPACE} -profile test_krakenuniq,docker --outdir ./results
+          attempt_limit: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           attempt_limit: 3
 
   krakenuniq:
-    name: Test mOTUs with workflow parameters
+    name: Test KrakenUniq with workflow parameters
     if: ${{ github.event_name != 'push' || (github.event_name == 'push' && github.repository == 'nf-core/taxprofiler') }}
     runs-on: ubuntu-latest
     strategy:

--- a/conf/test_krakenuniq.config
+++ b/conf/test_krakenuniq.config
@@ -16,7 +16,7 @@
 
 params {
     config_profile_name        = 'Test profile'
-    config_profile_description = 'Minimal test to check mOTUs function'
+    config_profile_description = 'Minimal test to check KrakenUniq function'
 
     // Limit resources so that this can run on GitHub Actions
     max_cpus   = 2

--- a/conf/test_krakenuniq.config
+++ b/conf/test_krakenuniq.config
@@ -1,0 +1,72 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/taxprofiler -profile test,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+//
+// Separate test as KrakenUniq database can sometimes be too big for GHA
+//
+
+params {
+    config_profile_name        = 'Test profile'
+    config_profile_description = 'Minimal test to check mOTUs function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = '6.GB'
+    max_time   = '6.h'
+
+    // Input data
+    // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
+    // TODO nf-core: Give any required params for the test so that command line flags are not needed
+    input                                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/taxprofiler/samplesheet.csv'
+    databases                             = 'https://raw.githubusercontent.com/nf-core/test-datasets/taxprofiler/database_krakenuniq.csv'
+    perform_shortread_qc                  = true
+    perform_longread_qc                   = true
+    shortread_qc_mergepairs               = true
+    perform_shortread_complexityfilter    = true
+    perform_shortread_hostremoval         = true
+    perform_longread_hostremoval          = true
+    perform_runmerging                    = true
+    hostremoval_reference                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                             = false`
+    run_kraken2                           = false`
+    run_bracken                           = false
+    run_malt                              = false
+    run_metaphlan3                        = false
+    run_centrifuge                        = false
+    run_diamond                           = false
+    run_krakenuniq                        = true
+    run_motus                             = false
+    run_krona                             = true
+    krona_taxonomy_directory              = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/sarscov2/metagenome/krona_taxonomy.tab'
+    malt_save_reads                       = true
+    kraken2_save_reads                    = true
+    centrifuge_save_reads                 = true
+    diamond_save_reads                    = true
+}
+
+process {
+    withName: MALT_RUN {
+        maxForks = 1
+    }
+    withName: MEGAN_RMA2INFO_TSV {
+        maxForks = 1
+    }
+    withName: MEGAN_RMA2INFO_KRONA {
+        maxForks = 1
+    }
+    withName: 'EIDO_VALIDATE' {
+        ext.args = '--st-index sample'
+    }
+    withName: 'EIDO_CONVERT' {
+        ext.args = '--st-index sample'
+    }
+}

--- a/conf/test_krakenuniq.config
+++ b/conf/test_krakenuniq.config
@@ -36,8 +36,8 @@ params {
     perform_longread_hostremoval          = true
     perform_runmerging                    = true
     hostremoval_reference                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = false`
-    run_kraken2                           = false`
+    run_kaiju                             = false
+    run_kraken2                           = false
     run_bracken                           = false
     run_malt                              = false
     run_metaphlan3                        = false

--- a/conf/test_motus.config
+++ b/conf/test_motus.config
@@ -10,6 +10,10 @@
 ----------------------------------------------------------------------------------------
 */
 
+//
+// Separate test as mOTUs database download can be flaky
+//
+
 params {
     config_profile_name        = 'mOTUs Test profile'
     config_profile_description = 'Minimal test to check mOTUs function'

--- a/nextflow.config
+++ b/nextflow.config
@@ -242,6 +242,7 @@ profiles {
     test_nopreprocessing    { includeConfig 'conf/test_nopreprocessing.config' }
     test_nothing            { includeConfig 'conf/test_nothing.config' }
     test_motus              { includeConfig 'conf/test_motus.config' }
+    test_krakenuniq         { includeConfig 'conf/test_krakenuniq.config' }
     test_pep                { includeConfig 'conf/test_pep.config' }
 }
 


### PR DESCRIPTION
As when database unpacked it results in 17GB which is more than 14GB, (but sometimes works withGHA? ) separating allows us to ignore it if necessary

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
