### PR TITLE
Updates MultiQC to 1.14 to add support for all our MQC modules!

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -336,3 +336,6 @@ extra_fn_clean_exts:
   - ".unmapped"
   - "_filtered"
   - "_processed"
+
+section_comments:
+  general_stats: "By default, all read count columns are displayed as millions (M) of reads."

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -171,16 +171,37 @@ table_columns_placement:
     non-primary_alignments: 1140
     reads_MQ0_percent: 1150
     error_rate: 1160
-  MALT:
-    "Num. of queries": 1200
-    Total reads: 1210
-    Mappability: 1220
-    Assig. Taxonomy: 1230
-    Taxonomic assignment success: 1240
+  Bracken:
+    "% Unclassified": 1200
+    "% Top 5": 1210
+  Centrifuge:
+    "% Unclassified": 1300
+    "% Top 5": 1310
+  diamond:
+    queries_aligned: 1400
   Kaiju:
-    assigned: 1300
-    "% Assigned": 1310
-    "% Unclassified": 1320
+    assigned: 1500
+    "% Assigned": 1510
+    "% Unclassified": 1520
+  Kraken:
+    "% Unclassified": 1600
+    "% Top 5": 1610
+  MALT:
+    "Num. of queries": 1700
+    Total reads: 1710
+    Mappability: 1720
+    Assig. Taxonomy: 1730
+    Taxonomic assignment success: 1740
+  motus:
+    Total number of reads: 1800
+    Number of reads after filtering: 1810
+    Total number of inserts: 1820
+    Unique mappers: 1830
+    Multiple mappers: 1840
+    Ignored multiple mapper without unique hit: 1850
+    "Number of ref-mOTUs": 1860
+    "Number of meta-mOTUs": 1870
+    "Number of ext-mOTUs": 1880
 
 table_columns_visible:
   FastQC (pre-Trimming):
@@ -256,7 +277,7 @@ table_columns_visible:
   Centrifuge:
     "% Unclassified": True
     "% Top 5": False
-  DIAMOND:
+  diamond:
     queries_aligned: True
   Kaiju:
     assigned: False
@@ -268,6 +289,16 @@ table_columns_visible:
     Mappability: True
     Assig. Taxonomy: False
     Taxonomic assignment success: True
+  motus:
+    Total number of reads: False
+    Number of reads after filtering: True
+    Total number of inserts: False
+    Unique mappers: True
+    Multiple mappers: True
+    Ignored multiple mapper without unique hit: False
+    "Number of ref-mOTUs": False
+    "Number of meta-mOTUs": False
+    "Number of ext-mOTUs": False
 
 table_columns_name:
   FastQC (pre-Trimming):

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -19,9 +19,10 @@ custom_logo_title: "nf-core/taxprofiler"
 run_modules:
   - fastqc
   - adapterRemoval
+  - fastp
   - bbduk
   - prinseqplusplus
-  - fastp
+  - porechop
   - filtlong
   - bowtie2
   - minimap2
@@ -32,8 +33,12 @@ run_modules:
   - diamond
   - malt
   - motus
-  - porechop
   - custom_content
+
+sp:
+  diamond:
+    contents: "diamond v"
+    num_lines: 10
 
 #extra_fn_clean_exts:
 #    - '_fastp'
@@ -102,9 +107,10 @@ table_columns_placement:
   FastQC (pre-Trimming):
     total_sequences: 100
     avg_sequence_length: 110
-    percent_duplicates: 120
-    percent_gc: 130
-    percent_fails: 140
+    median_sequence_length: 120
+    percent_duplicates: 130
+    percent_gc: 140
+    percent_fails: 150
   Falco (pre-Trimming):
     total_sequences: 200
     avg_sequence_length: 210
@@ -118,43 +124,63 @@ table_columns_placement:
     after_filtering_gc_content: 330
     after_filtering_q30_rate: 340
     after_filtering_q30_bases: 350
+    filtering_result_passed_filter_reads: 360
   Adapter Removal:
     aligned_total: 360
     percent_aligned: 370
     percent_collapsed: 380
     percent_discarded: 390
+  Porechop:
+    Input Reads: 400
+    Start Trimmed: 410
+    Start Trimmed Percent: 420
+    End Trimmed: 430
+    End Trimmed Percent: 440
+    Middle Split: 450
+    Middle Split Percent: 460
+  Filtlong:
+    Target bases: 500
   FastQC (post-Trimming):
-    total_sequences: 400
-    avg_sequence_length: 410
-    percent_duplicates: 420
-    percent_gc: 430
-    percent_fails: 440
+    total_sequences: 600
+    avg_sequence_length: 610
+    median_sequence_length: 620
+    percent_duplicates: 630
+    percent_gc: 640
+    percent_fails: 650
   Falco (post-Trimming):
-    total_sequences: 500
-    avg_sequence_length: 510
-    percent_duplicates: 520
-    percent_gc: 530
-    percent_fails: 540
+    total_sequences: 700
+    avg_sequence_length: 710
+    percent_duplicates: 720
+    percent_gc: 730
+    percent_fails: 740
+  BBDuk:
+    Input reads: 800
+    Total Removed bases percent: 810
+    Total Removed bases: 820
+    Total Removed reads percent: 830
+    Total Removed reads: 840
+  PRINSEQ++:
+    prinseqplusplus_total: 900
   bowtie2:
-    overall_alignment_rate: 600
+    overall_alignment_rate: 1000
   Samtools Stats:
-    raw_total_sequences: 700
-    reads_mapped: 710
-    reads_mapped_percent: 720
-    reads_properly_paired_percent: 730
-    non-primary_alignments: 740
-    reads_MQ0_percent: 750
-    error_rate: 760
+    raw_total_sequences: 1100
+    reads_mapped: 1110
+    reads_mapped_percent: 1120
+    reads_properly_paired_percent: 1130
+    non-primary_alignments: 1140
+    reads_MQ0_percent: 1150
+    error_rate: 1160
   MALT:
-    Num. of queries: 1000
-    Total reads: 1100
-    Mappability: 1200
-    Assig. Taxonomy: 1300
-    Taxonomic assignment success: 1400
+    "Num. of queries": 1200
+    Total reads: 1210
+    Mappability: 1220
+    Assig. Taxonomy: 1230
+    Taxonomic assignment success: 1240
   Kaiju:
-    assigned: 2000
-    "% Assigned": 2100
-    "% Unclassified": 2200
+    assigned: 1300
+    "% Assigned": 1310
+    "% Unclassified": 1320
 
 table_columns_visible:
   FastQC (pre-Trimming):
@@ -176,6 +202,16 @@ table_columns_visible:
     after_filtering_gc_content: False
     after_filtering_q30_rate: False
     after_filtering_q30_bases: False
+  porechop:
+    Input reads: False
+    Start Trimmed:
+    Start Trimmed Percent: True
+    End Trimmed: False
+    End Trimmed Percent: True
+    Middle Split: False
+    Middle Split Percent: True
+  Filtlong:
+    Target bases: True
   Adapter Removal:
     aligned_total: True
     percent_aligned: True
@@ -193,6 +229,14 @@ table_columns_visible:
     percent_duplicates: False
     percent_gc: False
     percent_fails: False
+  BBDuk:
+    Input reads: False
+    Total Removed bases Percent: False
+    Total Removed bases: False
+    Total Removed reads percent: True
+    Total Removed reads: False
+  "PRINSEQ++":
+    prinseqplusplus_total: True
   bowtie2:
     overall_alignment_rate: True
   Samtools Stats:
@@ -212,16 +256,19 @@ table_columns_visible:
   Centrifuge:
     "% Unclassified": True
     "% Top 5": False
-  MALT:
-    Num. of queries: True
-    Total reads: True
-    Mappability: True
-    Assig. Taxonomy: False
-    Taxonomic assignment success: True
+  DIAMOND:
+    queries_aligned: True
   Kaiju:
     assigned: False
     "% Assigned": False
     "% Unclassified": True
+  MALT:
+    "Num. of queries": True
+    Total reads: True
+    Mappability: True
+    Assig. Taxonomy: False
+    Taxonomic assignment success: True
+
 table_columns_name:
   FastQC (pre-Trimming):
     total_sequences: "Nr. Input Reads"
@@ -253,7 +300,10 @@ table_columns_name:
     reads_mapped_percent: "% Mapped Reads"
 
 extra_fn_clean_exts:
-  - ".kraken2.kraken2.report.txt"
-  - ".centrifuge.txt"
-  - ".bracken.kraken2.report.txt"
+  - "kraken2.report.txt"
+  - ".txt"
   - ".settings"
+  - ".bbduk"
+  - ".unmapped"
+  - "_filtered"
+  - "_processed"

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -177,7 +177,7 @@ table_columns_placement:
   Centrifuge:
     "% Unclassified": 1300
     "% Top 5": 1310
-  diamond:
+  DIAMOND:
     queries_aligned: 1400
   Kaiju:
     assigned: 1500
@@ -269,32 +269,30 @@ table_columns_visible:
     reads_MQ0_percent: False
     error_rate: False
   Kraken:
-    "% Unclassified": True
+    "% Unclassified": False
     "% Top 5": False
   Bracken:
-    "% Unclassified": True
+    "% Unclassified": False
     "% Top 5": False
-  Centrifuge:
-    "% Unclassified": True
-    "% Top 5": False
-  diamond:
-    queries_aligned: True
+  Centrifuge: False
+  DIAMOND:
+    queries_aligned: False
   Kaiju:
     assigned: False
     "% Assigned": False
-    "% Unclassified": True
+    "% Unclassified": False
   MALT:
-    "Num. of queries": True
-    Total reads: True
-    Mappability: True
+    "Num. of queries": False
+    Total reads: False
+    Mappability: False
     Assig. Taxonomy: False
-    Taxonomic assignment success: True
+    Taxonomic assignment success: False
   motus:
     Total number of reads: False
-    Number of reads after filtering: True
+    Number of reads after filtering: False
     Total number of inserts: False
-    Unique mappers: True
-    Multiple mappers: True
+    Unique mappers: False
+    Multiple mappers: False
     Ignored multiple mapper without unique hit: False
     "Number of ref-mOTUs": False
     "Number of meta-mOTUs": False

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -300,7 +300,6 @@ process {
         ext.args =  [
                 params.shortread_complexityfilter_prinseqplusplus_mode == 'dust' ? "-lc_dust=${params.shortread_complexityfilter_prinseqplusplus_dustscore}" : "-lc_entropy=${params.shortread_complexityfilter_entropy}",
                 "-trim_qual_left=0 -trim_qual_left=0 -trim_qual_window=0 -trim_qual_step=0",
-                "-VERBOSE 2"
             ].join(' ').trim()
         ext.prefix = { "${meta.id}-${meta.run_accession}" }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -280,7 +280,7 @@ process {
                 "entropywindow=${params.shortread_complexityfilter_bbduk_windowsize}",
                 params.shortread_complexityfilter_bbduk_mask ?  "entropymask=t" : "entropymask=f"
             ].join(' ').trim()
-        ext.prefix = { "${meta.id}-${meta.run_accession}" }
+        ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
             [
                 path: { "${params.outdir}/bbduk/" },
@@ -301,7 +301,7 @@ process {
                 params.shortread_complexityfilter_prinseqplusplus_mode == 'dust' ? "-lc_dust=${params.shortread_complexityfilter_prinseqplusplus_dustscore}" : "-lc_entropy=${params.shortread_complexityfilter_entropy}",
                 "-trim_qual_left=0 -trim_qual_left=0 -trim_qual_window=0 -trim_qual_step=0",
             ].join(' ').trim()
-        ext.prefix = { "${meta.id}-${meta.run_accession}" }
+        ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
             [
                 path: { "${params.outdir}/prinseqplusplus/" },
@@ -350,7 +350,7 @@ process {
 
     withName: KRAKEN2_KRAKEN2 {
         ext.args = params.kraken2_save_minimizers ? { "${meta.db_params} --report-minimizer-data" } : { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { meta.tool == "bracken" ? "${meta.id}-${meta.db_name}.bracken" : "${meta.id}-${meta.db_name}.kraken" } : { meta.tool == "bracken" ? "${meta.id}-${meta.run_accession}-${meta.db_name}.bracken" : "${meta.id}-${meta.run_accession}-${meta.db_name}.kraken" }
+        ext.prefix = params.perform_runmerging ? { meta.tool == "bracken" ? "${meta.id}_${meta.db_name}.bracken" : "${meta.id}_${meta.db_name}.kraken" } : { meta.tool == "bracken" ? "${meta.id}_${meta.run_accession}_${meta.db_name}.bracken" : "${meta.id}_${meta.run_accession}_${meta.db_name}.kraken" }
         publishDir = [
             path: { "${params.outdir}/kraken2/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -360,7 +360,7 @@ process {
 
     withName: BRACKEN_BRACKEN {
         errorStrategy = 'ignore'
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.bracken" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.bracken" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}.bracken" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}.bracken" }
         publishDir = [
             path: { "${params.outdir}/bracken/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -398,7 +398,7 @@ process {
     }
 
     withName: KRONA_CLEANUP {
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}" }
         publishDir = [
             path: { "${params.outdir}/krona/" },
             mode: params.publish_dir_mode,
@@ -407,7 +407,7 @@ process {
     }
 
     withName: KRONA_KTIMPORTTEXT {
-        ext.prefix = { "${meta.tool}-${meta.id}" }
+        ext.prefix = { "${meta.tool}_${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/krona/" },
             mode: params.publish_dir_mode,
@@ -417,12 +417,12 @@ process {
 
     withName: 'MEGAN_RMA2INFO_KRONA' {
         ext.args = { "--read2class Taxonomy" }
-        ext.prefix = { "${meta.id}-${meta.db_name}" }
+        ext.prefix = { "${meta.id}_${meta.db_name}" }
     }
 
     withName: KRONA_KTIMPORTTAXONOMY {
         ext.args = "-i"
-        ext.prefix = { "${meta.tool}-${meta.id}" }
+        ext.prefix = { "${meta.tool}_${meta.id}" }
         publishDir = [
             path: { "${params.outdir}/krona/" },
             mode: params.publish_dir_mode,
@@ -432,7 +432,7 @@ process {
 
     withName: METAPHLAN3_METAPHLAN3 {
         ext.args = { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.metaphlan3" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.metaphlan3" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}.metaphlan3" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}.metaphlan3" }
         publishDir = [
             path: { "${params.outdir}/metaphlan3/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -456,13 +456,13 @@ process {
             pattern: '*.{txt,sam,gz}'
         ]
         ext.args = { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.centrifuge" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.centrifuge" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}.centrifuge" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}.centrifuge" }
     }
 
     withName: CENTRIFUGE_KREPORT {
         errorStrategy = {task.exitStatus == 255 ? 'ignore' : 'retry'}
         ext.args = { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.centrifuge" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.centrifuge" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}.centrifuge" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}.centrifuge" }
         publishDir = [
             path: { "${params.outdir}/centrifuge/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -480,7 +480,7 @@ process {
     }
 
     withName: KAIJU_KAIJU {
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.kaiju" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.kaiju" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}.kaiju" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}.kaiju" }
         publishDir = [
             path: { "${params.outdir}/kaiju/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -504,7 +504,7 @@ process {
 
     withName: DIAMOND_BLASTX {
         ext.args = { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.diamond" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.diamond" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}.diamond" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}.diamond" }
         publishDir = [
             path: { "${params.outdir}/diamond/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -520,7 +520,7 @@ process {
                 params.motus_save_mgc_read_counts ?  "-M ${task.ext.prefix}.mgc" : ""
             ].join(',').replaceAll(','," ")
             }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}" }
         publishDir = [
             path: { "${params.outdir}/motus/${meta.db_name}/" },
             mode: params.publish_dir_mode

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -350,7 +350,7 @@ process {
 
     withName: KRAKEN2_KRAKEN2 {
         ext.args = params.kraken2_save_minimizers ? { "${meta.db_params} --report-minimizer-data" } : { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { meta.tool == "bracken" ? "${meta.id}-${meta.db_name}.bracken" : "${meta.id}-${meta.db_name}" } : { meta.tool == "bracken" ? "${meta.id}-${meta.run_accession}-${meta.db_name}.bracken" : "${meta.id}-${meta.run_accession}-${meta.db_name}" }
+        ext.prefix = params.perform_runmerging ? { meta.tool == "bracken" ? "${meta.id}-${meta.db_name}.bracken" : "${meta.id}-${meta.db_name}.kraken" } : { meta.tool == "bracken" ? "${meta.id}-${meta.run_accession}-${meta.db_name}.bracken" : "${meta.id}-${meta.run_accession}-${meta.db_name}.kraken" }
         publishDir = [
             path: { "${params.outdir}/kraken2/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -389,7 +389,7 @@ process {
     withName: KRAKENUNIQ_PRELOADEDKRAKENUNIQ {
         ext.args = { "${meta.db_params}" }
         // one run with multiple samples, so fix ID to just db name to ensure clean log name
-        ext.prefix = { "${meta.db_name}" }
+        ext.prefix = { "${meta.db_name}.krakenuniq" }
         publishDir = [
             path: { "${params.outdir}/krakenuniq/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -432,7 +432,7 @@ process {
 
     withName: METAPHLAN3_METAPHLAN3 {
         ext.args = { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.metaphlan3" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.metaphlan3" }
         publishDir = [
             path: { "${params.outdir}/metaphlan3/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -480,7 +480,7 @@ process {
     }
 
     withName: KAIJU_KAIJU {
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.kaiju" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.kaiju" }
         publishDir = [
             path: { "${params.outdir}/kaiju/${meta.db_name}/" },
             mode: params.publish_dir_mode,
@@ -504,7 +504,7 @@ process {
 
     withName: DIAMOND_BLASTX {
         ext.args = { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}" }
+        ext.prefix = params.perform_runmerging ? { "${meta.id}-${meta.db_name}.diamond" } : { "${meta.id}-${meta.run_accession}-${meta.db_name}.diamond" }
         publishDir = [
             path: { "${params.outdir}/diamond/${meta.db_name}/" },
             mode: params.publish_dir_mode,

--- a/modules.json
+++ b/modules.json
@@ -173,7 +173,7 @@
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
+                        "git_sha": "ee80d14721e76e2e079103b8dcd5d57129e584ba",
                         "installed_by": ["modules"]
                     },
                     "porechop/porechop": {

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -1,10 +1,10 @@
 process MULTIQC {
     label 'process_single'
 
-    conda "bioconda::multiqc=1.13"
+    conda "bioconda::multiqc=1.14"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.13--pyhdfd78af_0' :
-        'quay.io/biocontainers/multiqc:1.13--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.14--pyhdfd78af_0' :
+        'quay.io/biocontainers/multiqc:1.14--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"


### PR DESCRIPTION
- Updates MultiQC to 1.14
- Updates MultiQC config to in include latest MQC modules + column reordering etc.
- Adds tool-name to each `prefix` of each profiling tool so the tool name is in the profile name.

For the last point, I'm not yet sure if this makes sense. The reason why currently is that the log files in the general stats files only include the database name, so this is the only way to distinguish between which column is which (unless you hover over the column name - which otherwise doesn't say which tool it is from). Currently we get multiple rows with the same sample (just different database names), because the columns for each tool is different.

However, I'm now actually wondering what the utility is of displaying summary statistics of the (at least by default) classification tools in the GeneralStats table, as we have these summarised in the figures.

While maybe % reads classified for MALT or Kraken may be useful, including these makes a much less intuitive table... whereas if we turn these off (i.e., in GeneralStats only include the prepcoessing steps, which generally should have the same sample name), it'll make the table much more readable.

Thoughts?

i.e. 

![image](https://user-images.githubusercontent.com/17950287/212694315-f4c35f3e-fc03-467f-83ac-2e78450294ce.png)
 (thisi s confusing to me 

---

versus

![image](https://user-images.githubusercontent.com/17950287/212694451-76fbe17f-57af-4c3d-b6d8-dedb2243985f.png)


Which is much more readable to me