### PR TITLE
Dont fail on divide by 0 errors on centrifuge

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -471,6 +471,7 @@ process {
     }
 
     withName: KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE {
+        errorStrategy = { task.exitStatus in [255,1] ? 'ignore' : 'retry' }
         ext.prefix = { "centrifuge_${meta.id}_combined_reports" }
         publishDir = [
             path: { "${params.outdir}/centrifuge/" },


### PR DESCRIPTION
To fix

```
The exit status of the task that caused the workflow execution to fail was: 1.

The full error message was:

Error executing process > 'NFCORE_TAXPROFILER:TAXPROFILER:STANDARDISATION_PROFILES:KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE (1)'

Caused by:
  Process `NFCORE_TAXPROFILER:TAXPROFILER:STANDARDISATION_PROFILES:KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE (1)` terminated with an error exit status (1)

Command executed:

  combine_kreports.py \
      -r MOCK_002_Minion_R9_se_centrifuge-db.centrifuge.txt MOCK_001_Minion_R9_se_centrifuge-db.centrifuge.txt MOCK_001_Illumina_Hiseq_3000_se_centrifuge-db.centrifuge.txt MOCK_002_Illumina_Hiseq_3000_se_centrifuge-db.centrifuge.txt MOCK_003_Minion_R9_se_centrifuge-db.centrifuge.txt MOCK_003_Illumina_Hiseq_3000_se_centrifuge-db.centrifuge.txt \
      -o centrifuge_centrifuge-db_combined_reports.txt \
  
  
  cat <<-END_VERSIONS > versions.yml
  "NFCORE_TAXPROFILER:TAXPROFILER:STANDARDISATION_PROFILES:KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE":
      combine_kreports.py: 1.2
  END_VERSIONS

Command exit status:
  1

Command output:
  >>STEP 1: READING REPORTS
  	0/6 samples processed
  	1/6 samples processed
  	2/6 samples processed
  	3/6 samples processed
  	4/6 samples processed
  	5/6 samples processed
  	6/6 samples processed
  	6/6 samples processed
  >>STEP 2: WRITING NEW REPORT HEADERS
  >>STEP 3: PRINTING REPORT

Command error:
  WARNING: DEPRECATED USAGE: Forwarding SINGULARITYENV_TMPDIR as environment variable will not be supported in the future, use APPTAINERENV_TMPDIR instead
  WARNING: DEPRECATED USAGE: Forwarding SINGULARITYENV_NXF_DEBUG as environment variable will not be supported in the future, use APPTAINERENV_NXF_DEBUG instead
  Traceback (most recent call last):
    File "/usr/local/bin/combine_kreports.py", line 311, in 
      main()
    File "/usr/local/bin/combine_kreports.py", line 275, in main
      o_file.write("%0.4f\t" % (float(u_reads[0])/float(total_reads[0])*100))
  ZeroDivisionError: float division by zero

Work dir:
  /raven/ptmp/jfellowsy/nextflow/taxprofiler/work/c0/5bd158b311af71d26a397cdb16ab4a

Tip: you can replicate the issue by changing to the process work dir and entering the command `bash .command.run`
```

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
