### PR TITLE
Allow all tool's databases to be provided as `.tar.gz` files

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -471,6 +471,7 @@ process {
     }
 
     withName: KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE {
+        errorStrategy = { task.exitStatus in [255,1] ? 'ignore' : 'retry' }
         ext.prefix = { "centrifuge_${meta.id}_combined_reports" }
         publishDir = [
             path: { "${params.outdir}/centrifuge/" },

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -471,7 +471,6 @@ process {
     }
 
     withName: KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE {
-        errorStrategy = { task.exitStatus in [255,1] ? 'ignore' : 'retry' }
         ext.prefix = { "centrifuge_${meta.id}_combined_reports" }
         publishDir = [
             path: { "${params.outdir}/centrifuge/" },

--- a/subworkflows/local/db_check.nf
+++ b/subworkflows/local/db_check.nf
@@ -39,18 +39,10 @@ workflow DB_CHECK {
             skip: true
         }
 
-    //Filter the channel to run untar on DBs of tools actually using
+    // Filter the channel to untar only those databases for tools that are selected to be run by the user.
     ch_input_untar = ch_dbs_for_untar.untar.dump()
-                    .filter {
-                        params.run_bracken && it[0]['tool'] == 'bracken' ||
-                        params.run_centrifuge && it[0]['tool'] == 'centrifuge' ||
-                        params.run_diamond && it[0]['tool'] == 'diamond' ||
-                        params.run_kaiju && it[0]['tool'] == 'kaiju' ||
-                        params.run_kraken2 && it[0]['tool'] == 'kraken2' ||
-                        params.run_krakenuniq && it [0]['tool'] == 'krakenuniq' ||
-                        params.run_malt && it[0]['tool'] == 'malt' ||
-                        params.run_metaphlan3 && it[0]['tool'] == 'metaphlan3' ||
-                        params.run_motus && it[0]['tool'] == 'motus'
+                        .filter {
+                          params["run_${it[0]['tool']}"]
                         }
     UNTAR (ch_input_untar)
     ch_versions = ch_versions.mix(UNTAR.out.versions.first())

--- a/subworkflows/local/db_check.nf
+++ b/subworkflows/local/db_check.nf
@@ -41,7 +41,17 @@ workflow DB_CHECK {
 
     //Filter the channel to run untar on DBs of tools actually using
     ch_input_untar = ch_dbs_for_untar.untar.dump()
-                    .filter { params.run_bracken && it[0]['tool'] == 'bracken' || params.run_centrifuge && it[0]['tool'] == 'centrifuge' || || params.run_diamond && it[0]['tool'] == 'diamond' || params.run_kaiju && it[0]['tool'] == 'kaiju' || params.run_kraken2 && it[0]['tool'] == 'kraken2' || params.run_krakenuniq && it [0]['tool'] == 'krakenuniq' || params.run_malt && it[0]['tool'] == 'malt' || params.run_metaphlan3 && it[0]['tool'] == 'metaphlan3' || params.run_motus && it[0]['tool'] == 'motus' }
+                    .filter {
+                        params.run_bracken && it[0]['tool'] == 'bracken' ||
+                        params.run_centrifuge && it[0]['tool'] == 'centrifuge' ||
+                        params.run_diamond && it[0]['tool'] == 'diamond' ||
+                        params.run_kaiju && it[0]['tool'] == 'kaiju' ||
+                        params.run_kraken2 && it[0]['tool'] == 'kraken2' ||
+                        params.run_krakenuniq && it [0]['tool'] == 'krakenuniq' ||
+                        params.run_malt && it[0]['tool'] == 'malt' ||
+                        params.run_metaphlan3 && it[0]['tool'] == 'metaphlan3' ||
+                        params.run_motus && it[0]['tool'] == 'motus'
+                        }
     UNTAR (ch_input_untar)
     ch_versions = ch_versions.mix(UNTAR.out.versions.first())
     ch_final_dbs = ch_dbs_for_untar.skip.mix( UNTAR.out.untar )

--- a/subworkflows/local/db_check.nf
+++ b/subworkflows/local/db_check.nf
@@ -41,7 +41,7 @@ workflow DB_CHECK {
 
     //Filter the channel to run untar on DBs of tools actually using
     ch_input_untar = ch_dbs_for_untar.untar.dump()
-                    .filter {  params.run_kraken2 && it[0]['tool'] == 'kraken2' || params.run_centrifuge && it[0]['tool'] == 'centrifuge' || params.run_bracken && it[0]['tool'] == 'bracken' || params.run_kaiju && it[0]['tool'] == 'kaiju' || params.run_krakenuniq && it [0]['tool'] == 'krakenuniq' || params.run_malt && it[0]['tool'] == 'malt' || params.run_metaphlan3 && it[0]['tool'] == 'metaphlan3' }
+                    .filter { params.run_bracken && it[0]['tool'] == 'bracken' || params.run_centrifuge && it[0]['tool'] == 'centrifuge' || || params.run_diamond && it[0]['tool'] == 'diamond' || params.run_kaiju && it[0]['tool'] == 'kaiju' || params.run_kraken2 && it[0]['tool'] == 'kraken2' || params.run_krakenuniq && it [0]['tool'] == 'krakenuniq' || params.run_malt && it[0]['tool'] == 'malt' || params.run_metaphlan3 && it[0]['tool'] == 'metaphlan3' || params.run_motus && it[0]['tool'] == 'motus' }
     UNTAR (ch_input_untar)
     ch_versions = ch_versions.mix(UNTAR.out.versions.first())
     ch_final_dbs = ch_dbs_for_untar.skip.mix( UNTAR.out.untar )


### PR DESCRIPTION
Even if it doesn't make sense (e.g. with diamond), but there for consistency

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
