### PR TITLE
Filter  out nanopore data prior Metaphlan3

### DIFF
--- a/subworkflows/local/db_check.nf
+++ b/subworkflows/local/db_check.nf
@@ -40,7 +40,7 @@ workflow DB_CHECK {
         }
 
     //Filter the channel to run untar on DBs of tools actually using
-    ch_input_untar = ch_dbs_for_untar.untar.dump()
+    ch_input_untar = ch_dbs_for_untar.untar
                     .filter {  params.run_kraken2 && it[0]['tool'] == 'kraken2' || params.run_centrifuge && it[0]['tool'] == 'centrifuge' || params.run_bracken && it[0]['tool'] == 'bracken' || params.run_kaiju && it[0]['tool'] == 'kaiju' || params.run_krakenuniq && it [0]['tool'] == 'krakenuniq' || params.run_malt && it[0]['tool'] == 'malt' || params.run_metaphlan3 && it[0]['tool'] == 'metaphlan3' }
     UNTAR (ch_input_untar)
     ch_versions = ch_versions.mix(UNTAR.out.versions.first())

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -202,11 +202,8 @@ workflow PROFILING {
 
         ch_input_for_metaphlan3 = ch_input_for_profiling.metaphlan3
                             .filter{
-                                meta, report ->
-                                    if (meta.is_fasta) log.warn "[nf-core/taxprofiler] MetaPhlAn3 currently does not accept FASTA files as input. Skipping MetaPhlAn3 for sample ${meta.id}."
-                                    !meta.is_fasta
-                                    if ( meta['instrument_platform'] == 'OXFORD_NANOPORE' ) log.warn "[nf-core/taxprofiler] MetaPhlAn3 has not been evaluated for Nanopore data. Skipping MetaPhlAn3 for sample ${meta.id}."
-                                    meta['tool'] == 'metaphlan3' && meta['instrument_platform'] != 'OXFORD_NANOPORE'
+                                if (it[0].is_fasta || it[0].instrument_platform == 'OXFORD_NANOPORE' ) log.warn "[nf-core/taxprofiler] MetaPhlAn3 currently does not accept FASTA files as input and/or has not been evaluated for Nanopore data. Skipping MetaPhlAn3 for sample ${it[0].id}."
+                                !(it[0].is_fasta || it[0].instrument_platform == 'OXFORD_NANOPORE')
                             }
                             .multiMap {
                                 it ->

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -202,8 +202,11 @@ workflow PROFILING {
 
         ch_input_for_metaphlan3 = ch_input_for_profiling.metaphlan3
                             .filter{
-                                if (it[0].is_fasta) log.warn "[nf-core/taxprofiler] MetaPhlAn3 currently does not accept FASTA files as input. Skipping MetaPhlAn3 for sample ${it[0].id}."
-                                !it[0].is_fasta
+                                meta, report ->
+                                    if (meta.is_fasta) log.warn "[nf-core/taxprofiler] MetaPhlAn3 currently does not accept FASTA files as input. Skipping MetaPhlAn3 for sample ${meta.id}."
+                                    !meta.is_fasta
+                                    if ( meta['instrument_platform'] == 'OXFORD_NANOPORE' ) log.warn "[nf-core/taxprofiler] MetaPhlAn3 has not been evaluated for Nanopore data. Skipping MetaPhlAn3 for sample ${meta.id}."
+                                    meta['tool'] == 'metaphlan3' && meta['instrument_platform'] != 'OXFORD_NANOPORE'
                             }
                             .multiMap {
                                 it ->


### PR DESCRIPTION
As we keep finding this results in 100% classification (I expect due to BowTie2 mapping of very lon reads to short genes is not optmised)

Can check tests that only samples 2612/2613 are processed (2611 is fasta so should be excluded, as well as ERR* which is nanopore )

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
