### PR TITLE
MultiQC Tweaks after full-test experiments

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -268,12 +268,8 @@ table_columns_visible:
     non-primary_alignments: False
     reads_MQ0_percent: False
     error_rate: False
-  Kraken:
-    "% Unclassified": False
-    "% Top 5": False
-  Bracken:
-    "% Unclassified": False
-    "% Top 5": False
+  Kraken: False
+  Bracken: False
   Centrifuge: False
   DIAMOND:
     queries_aligned: False

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -271,28 +271,10 @@ table_columns_visible:
   Kraken: False
   Bracken: False
   Centrifuge: False
-  DIAMOND:
-    queries_aligned: False
-  Kaiju:
-    assigned: False
-    "% Assigned": False
-    "% Unclassified": False
-  MALT:
-    "Num. of queries": False
-    Total reads: False
-    Mappability: False
-    Assig. Taxonomy: False
-    Taxonomic assignment success: False
-  motus:
-    Total number of reads: False
-    Number of reads after filtering: False
-    Total number of inserts: False
-    Unique mappers: False
-    Multiple mappers: False
-    Ignored multiple mapper without unique hit: False
-    "Number of ref-mOTUs": False
-    "Number of meta-mOTUs": False
-    "Number of ext-mOTUs": False
+  DIAMOND: False
+  Kaiju: False
+  MALT: False
+  motus: False
 
 table_columns_name:
   FastQC (pre-Trimming):

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -350,7 +350,7 @@ process {
 
     withName: KRAKEN2_KRAKEN2 {
         ext.args = params.kraken2_save_minimizers ? { "${meta.db_params} --report-minimizer-data" } : { "${meta.db_params}" }
-        ext.prefix = params.perform_runmerging ? { meta.tool == "bracken" ? "${meta.id}_${meta.db_name}.bracken" : "${meta.id}_${meta.db_name}.kraken" } : { meta.tool == "bracken" ? "${meta.id}_${meta.run_accession}_${meta.db_name}.bracken" : "${meta.id}_${meta.run_accession}_${meta.db_name}.kraken" }
+        ext.prefix = params.perform_runmerging ? { meta.tool == "bracken" ? "${meta.id}_${meta.db_name}.bracken" : "${meta.id}_${meta.db_name}.kraken2" } : { meta.tool == "bracken" ? "${meta.id}_${meta.run_accession}_${meta.db_name}.bracken" : "${meta.id}_${meta.run_accession}_${meta.db_name}.kraken2" }
         publishDir = [
             path: { "${params.outdir}/kraken2/${meta.db_name}/" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -158,7 +158,7 @@ process {
             [
                 path: { "${params.outdir}/porechop" },
                 mode: params.publish_dir_mode,
-                pattern: '*.fastq.gz',
+                pattern: '*_porechopped.fastq.gz',
                 enabled: params.save_preprocessed_reads
             ],
             [

--- a/modules.json
+++ b/modules.json
@@ -179,7 +179,8 @@
                     "porechop/porechop": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": ["modules"],
+                        "patch": "modules/nf-core/porechop/porechop/porechop-porechop.diff"
                     },
                     "prinseqplusplus": {
                         "branch": "master",

--- a/modules/nf-core/porechop/porechop/main.nf
+++ b/modules/nf-core/porechop/porechop/main.nf
@@ -22,12 +22,16 @@ process PORECHOP_PORECHOP {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
+    ## To ensure ID matches rest of pipeline based on meta.id rather than input file name
+    mv $reads ${prefix}.fastq.gz
+
     porechop \\
         -i $reads \\
         -t $task.cpus \\
         $args \\
-        -o ${prefix}.fastq.gz \\
+        -o ${prefix}_porechopped.fastq.gz \\
         > ${prefix}.log
+
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
         porechop: \$( porechop --version )

--- a/modules/nf-core/porechop/porechop/porechop-porechop.diff
+++ b/modules/nf-core/porechop/porechop/porechop-porechop.diff
@@ -1,0 +1,23 @@
+Changes in module 'nf-core/porechop/porechop'
+--- modules/nf-core/porechop/porechop/main.nf
++++ modules/nf-core/porechop/porechop/main.nf
+@@ -22,12 +22,16 @@
+     def args = task.ext.args ?: ''
+     def prefix = task.ext.prefix ?: "${meta.id}"
+     """
++    ## To ensure ID matches rest of pipeline based on meta.id rather than input file name
++    mv $reads ${prefix}.fastq.gz
++
+     porechop \\
+         -i $reads \\
+         -t $task.cpus \\
+         $args \\
+-        -o ${prefix}.fastq.gz \\
++        -o ${prefix}_porechopped.fastq.gz \\
+         > ${prefix}.log
++
+     cat <<-END_VERSIONS > versions.yml
+     "${task.process}":
+         porechop: \$( porechop --version )
+
+************************************************************


### PR DESCRIPTION
- fixes wrong name in general stats  for porechop columns (have to patch the module)
- fixes the kraken2 report output names so it gets picked up by multiqc
- properly turns of Kraken2/Bracken in general stats

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
