### PR TITLE
Fix bracken receiving db_params from database sheet

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -244,24 +244,14 @@ process {
         ]
     }
 
-    withName: SAMTOOLS_VIEW {
+    withName: SAMTOOLS_FASTQ {
         ext.args = '-f 4'
-        ext.prefix = { "${meta.id}.mapped.sorted" }
-        publishDir = [
-            path: { "${params.outdir}/samtools/view" },
-            mode: params.publish_dir_mode,
-            enabled: params.save_hostremoval_unmapped,
-            pattern: '*.bam'
-        ]
-    }
-
-    withName: SAMTOOLS_BAM2FQ {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
-            path: { "${params.outdir}/samtools/bam2fq" },
+            path: { "${params.outdir}/samtools/fastq" },
             mode: params.publish_dir_mode,
             enabled: params.save_hostremoval_unmapped,
-            pattern: '*.fq.gz'
+            pattern: '*.fastq.gz'
         ]
     }
 
@@ -359,7 +349,7 @@ process {
     }
 
     withName: BRACKEN_BRACKEN {
-        errorStrategy = 'ignore'
+        ext.args = { "${meta.db_params}" }
         ext.prefix = params.perform_runmerging ? { "${meta.id}_${meta.db_name}.bracken" } : { "${meta.id}_${meta.run_accession}_${meta.db_name}.bracken" }
         publishDir = [
             path: { "${params.outdir}/bracken/${meta.db_name}/" },


### PR DESCRIPTION
Bracken doesn't recieve db_params from the database sheet

This is particularly a problem when you build the bracken database with a different read length than the default (100)

This currently does not solve the issue of with our current structure, that the pre-bracken kraken2 run would also receive the bracken options and v.v.

Partly closes #233 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
