### PR TITLE
Fix exporting of mapped/unmapped reads for consistency across both short and long reads

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -201,6 +201,7 @@ process {
         ]
     }
 
+    // Saving unmapped reads as FQ comes via input channel!
     withName: BOWTIE2_ALIGN {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }
         publishDir = [
@@ -212,7 +213,7 @@ process {
             [
                 path: { "${params.outdir}/bowtie2/align" },
                 mode: params.publish_dir_mode,
-                enabled: params.save_hostremoval_mapped,
+                enabled: params.save_hostremoval_bam,
                 pattern: '*.bam'
             ],
             [
@@ -239,24 +240,18 @@ process {
         publishDir = [
             path: { "${params.outdir}/minimap2/align" },
             mode: params.publish_dir_mode,
-            enabled: params.save_hostremoval_mapped,
+            enabled: params.save_hostremoval_bam,
             pattern: '*.bam'
         ]
     }
 
     withName: SAMTOOLS_VIEW {
         ext.args = '-f 4'
-        ext.prefix = { "${meta.id}.mapped.sorted" }
-        publishDir = [
-            path: { "${params.outdir}/samtools/view" },
-            mode: params.publish_dir_mode,
-            enabled: params.save_hostremoval_unmapped,
-            pattern: '*.bam'
-        ]
+        ext.prefix = { "${meta.id}_${meta.run_accession}.unmapped" }
     }
 
     withName: SAMTOOLS_BAM2FQ {
-        ext.prefix = { "${meta.id}_${meta.run_accession}" }
+        ext.prefix = { "${meta.id}_${meta.run_accession}.unmapped" }
         publishDir = [
             path: { "${params.outdir}/samtools/bam2fq" },
             mode: params.publish_dir_mode,

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -30,7 +30,7 @@ params {
     perform_shortread_hostremoval = true
     perform_longread_hostremoval = true
     save_hostremoval_index = true
-    save_hostremoval_mapped = true
+    save_hostremoval_bam = true
     save_hostremoval_unmapped = true
 
     perform_runmerging = true

--- a/nextflow.config
+++ b/nextflow.config
@@ -103,7 +103,7 @@ params {
     shortread_hostremoval_index            = null
     longread_hostremoval_index             = null
     save_hostremoval_index                 = false
-    save_hostremoval_mapped                = false
+    save_hostremoval_bam                = false
     save_hostremoval_unmapped              = false
 
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -293,7 +293,7 @@
                     "description": "Save mapping index of input reference when not already supplied by user",
                     "help_text": "Save the output files of the in-built indexing of the host genome.\n\nThis is recommend to be turned on if you plan to use the same reference genome multiple times, as supplying the directory or file to `--shortread_hostremoval_index` or `--longread_hostremoval_index` respectively can speed up runtime of future runs. Once generated, we recommend you place this file _outside_ of your run results directory in a central 'cache' directory you and others using your machine can access and supply to the pipeline."
                 },
-                "save_hostremoval_mapped": {
+                "save_hostremoval_bam": {
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
                     "description": "Saved mapped and unmapped reads in BAM format from host removal",
@@ -303,7 +303,7 @@
                     "type": "boolean",
                     "fa_icon": "fas fa-save",
                     "description": "Save unmapped reads in FASTQ format from host removal",
-                    "help_text": "Save the unreads mapped to the reference genome in FASTQ format (as exported from `samtools view`).\n\nThis can be useful if you wish to perform other analyses on the off-target reads from the host mapping, such as manual profiling or _de novo_ assembly."
+                    "help_text": "Save only the reads NOT mapped to the reference genome in FASTQ format (as exported from `samtools view` and `bam2fq`).\n\nThis can be useful if you wish to perform other analyses on the off-target reads from the host mapping, such as manual profiling or _de novo_ assembly."
                 }
             },
             "fa_icon": "fas fa-user-times"

--- a/subworkflows/local/longread_hostremoval.nf
+++ b/subworkflows/local/longread_hostremoval.nf
@@ -34,14 +34,15 @@ workflow LONGREAD_HOSTREMOVAL {
                 [ meta, reads, [] ]
         }
 
-
+    // Generate unmapped reads FASTQ for downstream taxprofiling
     SAMTOOLS_VIEW ( ch_minimap2_mapped , [], [] )
     ch_versions      = ch_versions.mix( SAMTOOLS_VIEW.out.versions.first() )
 
     SAMTOOLS_BAM2FQ ( SAMTOOLS_VIEW.out.bam, false )
     ch_versions      = ch_versions.mix( SAMTOOLS_BAM2FQ.out.versions.first() )
 
-    SAMTOOLS_INDEX ( SAMTOOLS_VIEW.out.bam )
+    // Indexing whole BAM for host removal statistics
+    SAMTOOLS_INDEX ( MINIMAP2_ALIGN.out.bam )
     ch_versions      = ch_versions.mix( SAMTOOLS_INDEX.out.versions.first() )
 
     bam_bai = MINIMAP2_ALIGN.out.bam
@@ -50,7 +51,6 @@ workflow LONGREAD_HOSTREMOVAL {
     SAMTOOLS_STATS ( bam_bai, reference )
     ch_versions = ch_versions.mix(SAMTOOLS_STATS.out.versions.first())
     ch_multiqc_files = ch_multiqc_files.mix( SAMTOOLS_STATS.out.stats )
-
 
     emit:
     stats    = SAMTOOLS_STATS.out.stats     //channel: [val(meta), [reads  ] ]


### PR DESCRIPTION
Also reduces the number of unnecessary processes

Now the output BAM from host removal contains both mapped  AND unmapped reads. There is no option for mapped reads only in output BAMs, as we consider a user can do this if they feel necessary (as we don't used mapped reads anyway)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
