### PR TITLE
Fix KrakenUniq Taxpasta issue

### DIFF
--- a/subworkflows/local/standardisation_profiles.nf
+++ b/subworkflows/local/standardisation_profiles.nf
@@ -24,16 +24,16 @@ workflow STANDARDISATION_PROFILES {
     //Taxpasta standardisation
     ch_input_for_taxpasta = profiles
                             .map {
-                                meta, profile ->
-                                    def meta_new = [:]
-                                    meta_new.id = meta.db_name
-                                    meta_new.tool = meta.tool == 'metaphlan3' ? 'metaphlan' : meta.tool == 'malt' ? 'megan6' : meta.tool
-                                    [meta_new, profile]
-                                }
-                                .groupTuple ()
+                                    meta, profile ->
+                                        def meta_new = [:]
+                                        meta_new.id = meta.db_name
+                                        meta_new.tool = meta.tool == 'metaphlan3' ? 'metaphlan' : meta.tool == 'malt' ? 'megan6' : meta.tool
+                                        [meta_new, profile]
+                            }
+                            .groupTuple ()
+                            .map { [ it[0], it[1].flatten() ] }
 
     TAXPASTA_MERGE (ch_input_for_taxpasta, [], [])
-
 
     /*
         Split profile results based on tool they come from


### PR DESCRIPTION
KrakenUniq runs on multiple samples at once , therefore the output is already a list. Adding a groupTuple puts a list in a list (which goes too deep for NXF to pick it up as a path), resulting in

![image](https://user-images.githubusercontent.com/17950287/220551470-2d5a0b19-dfc6-404c-ba66-474d773ddccd.png)


This would presumably also affect MALT.

This fix flattens the list after the groupTuple'ing to make sure it's a single file list that can be picked up by the TAXPASTA_MERGE NXF module