### PR TITLE
Update taxpasta/merge to version 0.2.0 and add taxonomy argument

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -546,7 +546,7 @@ process {
         ext.args =  {
             [
                 "-p ${meta.tool} -o ${meta.tool}_${meta.id}.${params.standardisation_taxpasta_format}",
-                params.taxpasta_add_taxonomy ? "--taxonomy" : "",
+                params.taxpasta_taxonomy_files ? "--taxonomy" : "",
             ].join(' ').trim()
             }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -546,7 +546,7 @@ process {
         ext.args =  {
             [
                 "-p ${meta.tool} -o ${meta.tool}_${meta.id}.${params.standardisation_taxpasta_format}",
-                params.taxpasta_taxonomy_dir ? "--taxonomy" ${params.taxpasta_taxonomy_dir}" : "",
+                params.taxpasta_taxonomy_dir ? "--taxonomy ${params.taxpasta_taxonomy_dir}" : "",
             ].join(' ').trim()
             }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -550,7 +550,7 @@ process {
                 params.taxpasta_add_name ?  "--add-name" : "",
                 params.taxpasta_add_rank ? "--add-rank" : "",
                 params.taxpasta_add_lineage ? "--add-lineage" : "",
-                params.taxpasta_add_idlineage ? "--add-id-lineage" : "",
+                params.taxpasta_add_idlineage ? "--add-id-lineage" : ""
             ].join(' ').trim()
             }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -546,7 +546,7 @@ process {
         ext.args =  {
             [
                 "-p ${meta.tool} -o ${meta.tool}_${meta.id}.${params.standardisation_taxpasta_format}",
-                params.taxpasta_taxonomy_files ? "--taxonomy" : "",
+                params.taxpasta_taxonomy_dir ? "--taxonomy" ${params.taxpasta_taxonomy_dir}" : "",
             ].join(' ').trim()
             }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -547,6 +547,10 @@ process {
             [
                 "-p ${meta.tool} -o ${meta.tool}_${meta.id}.${params.standardisation_taxpasta_format}",
                 params.taxpasta_taxonomy_dir ? "--taxonomy ${params.taxpasta_taxonomy_dir}" : "",
+                params.taxpasta_add_name ?  "--add-name" : "",
+                params.taxpasta_add_rank ? "--add-rank" : "",
+                params.taxpasta_add_lineage ? "--add-lineage" : "",
+                params.taxpasta_add_idlineage ? "--add-id-lineage" : "",
             ].join(' ').trim()
             }
         publishDir = [

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -543,7 +543,12 @@ process {
     }
 
     withName: TAXPASTA_MERGE {
-        ext.args =  { "-p ${meta.tool} -o ${meta.tool}_${meta.id}.${params.standardisation_taxpasta_format}" }
+        ext.args =  {
+            [
+                "-p ${meta.tool} -o ${meta.tool}_${meta.id}.${params.standardisation_taxpasta_format}",
+                params.taxpasta_add_taxonomy ? "--taxonomy" : "",
+            ].join(' ').trim()
+            }
         publishDir = [
             path: { "${params.outdir}/taxpasta/" },
             mode: params.publish_dir_mode,

--- a/docs/output.md
+++ b/docs/output.md
@@ -449,7 +449,7 @@ The resulting HTML files can be loaded into your web browser for exploration. Ea
 
   </details>
 
-By enabling the parameter `--taxonomy` and giving the path to a directory containing taxdump files, the taxon name, the taxon rank and the taxon's entire lineage can be added in the output. Those should be configured through `ext.args` by respectively using the parameters `--add-name`, `--add-rank` and `--add-lineage`.
+By enabling the parameter `--taxonomy` and giving the path to a directory containing taxdump files, the taxon name, the taxon rank, the taxon's entire lineage including taxon names and the taxon's entire lineage including taxon identifiers can be added in the output. Those should be configured through `ext.args` by respectively using the parameters `--add-name`, `--add-rank`, `--add-lineage` and `--add-id-lineage`.
 
 These files will likely be the most useful files for the comparison of differences in classification between different tools or building consensuses, with the caveat they have slightly less information than the actual output from each tool (which may have non-standard information e.g. taxonomic rank, percentage of hits, abundance estimations).
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -449,7 +449,7 @@ The resulting HTML files can be loaded into your web browser for exploration. Ea
 
   </details>
 
-By enabling the parameter `--taxonomy` and giving the path to a directory containing taxdump files, the taxon name, the taxon rank, the taxon's entire lineage including taxon names and the taxon's entire lineage including taxon identifiers can be added in the output. Those should be configured through `ext.args` by respectively using the parameters `--add-name`, `--add-rank`, `--add-lineage` and `--add-id-lineage`.
+By providing the path to a directory containing taxdump files to `--taxpasta_taxonomy_dir`, the taxon name, the taxon rank, the taxon's entire lineage including taxon names and/or the taxon's entire lineage including taxon identifiers can also be added in the output in addition to just the taxon ID. Addition of this extra information can be turned by using the parameters `--add-name`, `--add-rank`, `--add-lineage` and `--add-id-lineage` respectively.
 
 These files will likely be the most useful files for the comparison of differences in classification between different tools or building consensuses, with the caveat they have slightly less information than the actual output from each tool (which may have non-standard information e.g. taxonomic rank, percentage of hits, abundance estimations).
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -449,7 +449,7 @@ The resulting HTML files can be loaded into your web browser for exploration. Ea
 
   </details>
 
-By providing the path to a directory containing taxdump files to `--taxpasta_taxonomy_dir`, the taxon name, the taxon rank, the taxon's entire lineage including taxon names and/or the taxon's entire lineage including taxon identifiers can also be added in the output in addition to just the taxon ID. Addition of this extra information can be turned by using the parameters `--add-name`, `--add-rank`, `--add-lineage` and `--add-id-lineage` respectively.
+By providing the path to a directory containing taxdump files to `--taxpasta_taxonomy_dir`, the taxon name, the taxon rank, the taxon's entire lineage including taxon names and/or the taxon's entire lineage including taxon identifiers can also be added in the output in addition to just the taxon ID. Addition of this extra information can be turned by using the parameters `--taxpasta_add_name`, `--taxpasta_add_rank`, `--taxpasta_add_lineage` and `--taxpasta_add_idlineage` respectively.
 
 These files will likely be the most useful files for the comparison of differences in classification between different tools or building consensuses, with the caveat they have slightly less information than the actual output from each tool (which may have non-standard information e.g. taxonomic rank, percentage of hits, abundance estimations).
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -449,6 +449,8 @@ The resulting HTML files can be loaded into your web browser for exploration. Ea
 
   </details>
 
+By enabling the parameter `--taxonomy` and giving the path to a directory containing taxdump files, the taxon name, the taxon rank and the taxon's entire lineage can be added in the output. Those should be configured through `ext.args` by respectively using the parameters `--add-name`, `--add-rank` and `--add-lineage`.
+
 These files will likely be the most useful files for the comparison of differences in classification between different tools or building consensuses, with the caveat they have slightly less information than the actual output from each tool (which may have non-standard information e.g. taxonomic rank, percentage of hits, abundance estimations).
 
 The following report files are used for the taxpasta step:

--- a/modules.json
+++ b/modules.json
@@ -209,7 +209,7 @@
                     },
                     "taxpasta/merge": {
                         "branch": "master",
-                        "git_sha": "74ab450ed05e034d049c00f6e2853de2c31594b4",
+                        "git_sha": "fe58454add6225d2b7468e6d72a3a1f6a3149638",
                         "installed_by": ["modules"]
                     },
                     "untar": {

--- a/modules.json
+++ b/modules.json
@@ -8,298 +8,214 @@
                     "adapterremoval": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bbmap/bbduk": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bowtie2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bowtie2/build": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bracken/bracken": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "bracken/combinebrackenoutputs": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "centrifuge/centrifuge": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "centrifuge/kreport": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "diamond/blastx": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "falco": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/falco/falco.diff"
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "filtlong": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "kaiju/kaiju": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "kaiju/kaiju2krona": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "kaiju/kaiju2table": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "kraken2/kraken2": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "krakentools/combinekreports": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "krakentools/kreport2krona": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "krakenuniq/preloadedkrakenuniq": {
                         "branch": "master",
                         "git_sha": "a6eb17f65b3ee5761c25c075a6166c9f76733cee",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "krona/ktimporttaxonomy": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "krona/ktimporttext": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "malt/run": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "megan/rma2info": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "metaphlan3/mergemetaphlantables": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "metaphlan3/metaphlan3": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "minimap2/index": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "motus/merge": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "motus/profile": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "ee80d14721e76e2e079103b8dcd5d57129e584ba",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "porechop/porechop": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ],
+                        "installed_by": ["modules"],
                         "patch": "modules/nf-core/porechop/porechop/porechop-porechop.diff"
                     },
                     "prinseqplusplus": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/bam2fq": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "samtools/view": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "taxpasta/merge": {
                         "branch": "master",
                         "git_sha": "fe58454add6225d2b7468e6d72a3a1f6a3149638",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     },
                     "untar": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": [
-                            "modules"
-                        ]
+                        "installed_by": ["modules"]
                     }
                 }
             }

--- a/modules.json
+++ b/modules.json
@@ -8,214 +8,298 @@
                     "adapterremoval": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bbmap/bbduk": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bowtie2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bowtie2/build": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bracken/bracken": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "bracken/combinebrackenoutputs": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "cat/fastq": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "centrifuge/centrifuge": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "centrifuge/kreport": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "diamond/blastx": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "falco": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/falco/falco.diff"
                     },
                     "fastp": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "fastqc": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "filtlong": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "gunzip": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kaiju/kaiju": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kaiju/kaiju2krona": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kaiju/kaiju2table": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "kraken2/kraken2": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "krakentools/combinekreports": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "krakentools/kreport2krona": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "krakenuniq/preloadedkrakenuniq": {
                         "branch": "master",
                         "git_sha": "a6eb17f65b3ee5761c25c075a6166c9f76733cee",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "krona/ktimporttaxonomy": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "krona/ktimporttext": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "malt/run": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "megan/rma2info": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "metaphlan3/mergemetaphlantables": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "metaphlan3/metaphlan3": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "minimap2/align": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "minimap2/index": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "motus/merge": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "motus/profile": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "multiqc": {
                         "branch": "master",
                         "git_sha": "ee80d14721e76e2e079103b8dcd5d57129e584ba",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "porechop/porechop": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"],
+                        "installed_by": [
+                            "modules"
+                        ],
                         "patch": "modules/nf-core/porechop/porechop/porechop-porechop.diff"
                     },
                     "prinseqplusplus": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/bam2fq": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/index": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/stats": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "samtools/view": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "taxpasta/merge": {
                         "branch": "master",
                         "git_sha": "fe58454add6225d2b7468e6d72a3a1f6a3149638",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     },
                     "untar": {
                         "branch": "master",
                         "git_sha": "c8e35eb2055c099720a75538d1b8adb3fb5a464c",
-                        "installed_by": ["modules"]
+                        "installed_by": [
+                            "modules"
+                        ]
                     }
                 }
             }

--- a/modules/nf-core/taxpasta/merge/main.nf
+++ b/modules/nf-core/taxpasta/merge/main.nf
@@ -2,10 +2,10 @@ process TAXPASTA_MERGE {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::taxpasta=0.1.1"
+    conda "bioconda::taxpasta=0.2.0"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/taxpasta:0.1.1--pyhdfd78af_0':
-        'quay.io/biocontainers/taxpasta:0.1.1--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/taxpasta:0.2.0--pyhdfd78af_0':
+        'quay.io/biocontainers/taxpasta:0.2.0--pyhdfd78af_0' }"
 
 
     input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -157,7 +157,7 @@ params {
     // profile standardisation
     run_profile_standardisation             = false
     standardisation_taxpasta_format         = 'tsv'
-    taxpasta_taxonomy_dir                   = false
+    taxpasta_taxonomy_dir                   = null
     taxpasta_add_name                       = false
     taxpasta_add_rank                       = false
     taxpasta_add_lineage                    = false

--- a/nextflow.config
+++ b/nextflow.config
@@ -157,7 +157,7 @@ params {
     // profile standardisation
     run_profile_standardisation             = false
     standardisation_taxpasta_format         = 'tsv'
-    taxpasta_taxonomy_files                 = false
+    taxpasta_taxonomy_dir                   = false
     standardisation_motus_generatebiom      = false
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -157,7 +157,7 @@ params {
     // profile standardisation
     run_profile_standardisation             = false
     standardisation_taxpasta_format         = 'tsv'
-    taxpasta_add_taxonomy                   = false
+    taxpasta_taxonomy_files                 = false
     standardisation_motus_generatebiom      = false
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -158,6 +158,10 @@ params {
     run_profile_standardisation             = false
     standardisation_taxpasta_format         = 'tsv'
     taxpasta_taxonomy_dir                   = false
+    taxpasta_add_name                       = false
+    taxpasta_add_rank                       = false
+    taxpasta_add_lineage                    = false
+    taxpasta_add_idlineage                  = false
     standardisation_motus_generatebiom      = false
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -157,6 +157,7 @@ params {
     // profile standardisation
     run_profile_standardisation             = false
     standardisation_taxpasta_format         = 'tsv'
+    taxpasta_add_taxonomy                   = false
     standardisation_motus_generatebiom      = false
 }
 

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -535,7 +535,7 @@
                 "taxpasta_add_lineage": {
                     "type": "boolean",
                     "description": "Add the taxon's entire lineage to the output.",
-                    "help_text": "\nThe standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon's entire lineage with the taxon names separated by semi-colons can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `taxpasta_add_lineage`\n"
+                    "help_text": "\nThe standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon's entire lineage with the taxon names separated by semi-colons can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `--taxpasta_add_lineage`\n"
                 },
                 "taxpasta_add_idlineage": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -530,7 +530,7 @@
                 "taxpasta_add_rank": {
                     "type": "boolean",
                     "description": "Add the taxon rank to the output.",
-                    "help_text": "The standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon rank can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `taxpasta_add_rank`"
+                    "help_text": "The standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon rank can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `--taxpasta_add_rank`"
                 },
                 "taxpasta_add_lineage": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -521,6 +521,28 @@
                     "type": "boolean",
                     "description": "The path to a directory containing taxdump files.",
                     "help_text": "At least nodes.dmp and names.dmp are required. A merged.dmp file is optional."
+                },
+                "taxpasta_add_name": {
+                    "type": "string",
+                    "default": "false",
+                    "description": "Add the taxon name to the output."
+                },
+                "taxpasta_add_rank": {
+                    "type": "string",
+                    "default": "false",
+                    "description": "Add the taxon rank to the output."
+                },
+                "taxpasta_add_lineage": {
+                    "type": "string",
+                    "default": "false",
+                    "description": "Add the taxon's entire lineage to the output.",
+                    "help_text": "These are taxon names separated by semi-colons.   "
+                },
+                "taxpasta_add_idlineage": {
+                    "type": "string",
+                    "default": "false",
+                    "description": "Add the taxon's entire lineage to the output.",
+                    "help_text": "These are taxon identifiers separated by semi-colons. "
                 }
             },
             "fa_icon": "fas fa-chart-line"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -523,24 +523,20 @@
                     "help_text": "At least nodes.dmp and names.dmp are required. A merged.dmp file is optional."
                 },
                 "taxpasta_add_name": {
-                    "type": "string",
-                    "default": "false",
+                    "type": "boolean",
                     "description": "Add the taxon name to the output."
                 },
                 "taxpasta_add_rank": {
-                    "type": "string",
-                    "default": "false",
+                    "type": "boolean",
                     "description": "Add the taxon rank to the output."
                 },
                 "taxpasta_add_lineage": {
-                    "type": "string",
-                    "default": "false",
+                    "type": "boolean",
                     "description": "Add the taxon's entire lineage to the output.",
                     "help_text": "These are taxon names separated by semi-colons.   "
                 },
                 "taxpasta_add_idlineage": {
-                    "type": "string",
-                    "default": "false",
+                    "type": "boolean",
                     "description": "Add the taxon's entire lineage to the output.",
                     "help_text": "These are taxon identifiers separated by semi-colons. "
                 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -540,7 +540,7 @@
                 "taxpasta_add_idlineage": {
                     "type": "boolean",
                     "description": "Add the taxon's entire lineage to the output.",
-                    "help_text": "\nThe standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon's entire lineage with the taxon identifiers separated by semi-colons can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `taxpasta_add_idlineage`\n"
+                    "help_text": "\nThe standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon's entire lineage with the taxon identifiers separated by semi-colons can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `--taxpasta_add_idlineage`\n"
                 }
             },
             "fa_icon": "fas fa-chart-line"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -516,6 +516,11 @@
                     "fa_icon": "fas fa-file",
                     "description": "The desired output format.",
                     "enum": ["tsv", "csv", "arrow", "parquet", "biom"]
+                },
+                "taxpasta_add_taxonomy": {
+                    "type": "boolean",
+                    "description": "The path to a directory containing taxdump files.",
+                    "help_text": "At least nodes.dmp and names.dmp are required. A merged.dmp file is optional."
                 }
             },
             "fa_icon": "fas fa-chart-line"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -520,25 +520,27 @@
                 "taxpasta_taxonomy_dir": {
                     "type": "string",
                     "description": "The path to a directory containing taxdump files.",
-                    "help_text": "At least nodes.dmp and names.dmp are required. A merged.dmp file is optional."
+                    "help_text": "This arguments provides the path to the directory containing taxdump files. At least nodes.dmp and names.dmp are required. A merged.dmp file is optional. \n\nModifies tool parameter(s):\n-taxpasta: `--taxpasta_taxonomy_dir`"
                 },
                 "taxpasta_add_name": {
                     "type": "boolean",
-                    "description": "Add the taxon name to the output."
+                    "description": "Add the taxon name to the output.",
+                    "help_text": "The standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon name can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `taxpasta_add_name`"
                 },
                 "taxpasta_add_rank": {
                     "type": "boolean",
-                    "description": "Add the taxon rank to the output."
+                    "description": "Add the taxon rank to the output.",
+                    "help_text": "The standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon rank can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `taxpasta_add_rank`"
                 },
                 "taxpasta_add_lineage": {
                     "type": "boolean",
                     "description": "Add the taxon's entire lineage to the output.",
-                    "help_text": "These are taxon names separated by semi-colons.   "
+                    "help_text": "\nThe standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon's entire lineage with the taxon names separated by semi-colons can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `taxpasta_add_lineage`\n"
                 },
                 "taxpasta_add_idlineage": {
                     "type": "boolean",
                     "description": "Add the taxon's entire lineage to the output.",
-                    "help_text": "These are taxon identifiers separated by semi-colons. "
+                    "help_text": "\nThe standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon's entire lineage with the taxon identifiers separated by semi-colons can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `taxpasta_add_idlineage`\n"
                 }
             },
             "fa_icon": "fas fa-chart-line"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -518,7 +518,7 @@
                     "enum": ["tsv", "csv", "arrow", "parquet", "biom"]
                 },
                 "taxpasta_taxonomy_dir": {
-                    "type": "boolean",
+                    "type": "string",
                     "description": "The path to a directory containing taxdump files.",
                     "help_text": "At least nodes.dmp and names.dmp are required. A merged.dmp file is optional."
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -525,7 +525,7 @@
                 "taxpasta_add_name": {
                     "type": "boolean",
                     "description": "Add the taxon name to the output.",
-                    "help_text": "The standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon name can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `taxpasta_add_name`"
+                    "help_text": "The standard output format of taxpasta is a two-column table including the read counts and the integer taxonomic ID. The taxon name can be added as additional information to the output table.\n\nModifies tool parameter(s):\n- taxpasta: `--taxpasta_add_name`"
                 },
                 "taxpasta_add_rank": {
                     "type": "boolean",

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -517,7 +517,7 @@
                     "description": "The desired output format.",
                     "enum": ["tsv", "csv", "arrow", "parquet", "biom"]
                 },
-                "taxpasta_taxonomy_files": {
+                "taxpasta_taxonomy_dir": {
                     "type": "boolean",
                     "description": "The path to a directory containing taxdump files.",
                     "help_text": "At least nodes.dmp and names.dmp are required. A merged.dmp file is optional."

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -517,7 +517,7 @@
                     "description": "The desired output format.",
                     "enum": ["tsv", "csv", "arrow", "parquet", "biom"]
                 },
-                "taxpasta_add_taxonomy": {
+                "taxpasta_taxonomy_files": {
                     "type": "boolean",
                     "description": "The path to a directory containing taxdump files.",
                     "help_text": "At least nodes.dmp and names.dmp are required. A merged.dmp file is optional."


### PR DESCRIPTION
This PR add the latest version of taxpasta/merge and adds taxonomy as argument.

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
