### PR TITLE
Deactivate saving of reads and other large files for full tests

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -53,16 +53,15 @@ params {
     krakenuniq_save_readclassifications = false
 
     run_bracken                         = true
-        
     run_malt                            = true
     malt_save_reads                     = false
     malt_generate_megansummary          = true
-        
+
     run_metaphlan3                      = true
-        
+
     run_motus                           = true
     motus_save_mgc_read_counts          = true
-        
+
     run_profile_standardisation         = true
     run_krona                           = true
 }

--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -19,52 +19,52 @@ params {
     // Genome references
     hostremoval_reference = 'ftp://ftp.ncbi.nlm.nih.gov/genomes/all/GCA/000/819/615/GCA_000819615.1_ViralProj14015/GCA_000819615.1_ViralProj14015_genomic.fna.gz'
 
-    save_preprocessed_reads = true
+    save_preprocessed_reads             = false
 
-    perform_shortread_qc = true
-    shortread_qc_mergepairs = true
-    perform_shortread_complexityfilter = true
-    save_complexityfiltered_reads = true
+    perform_shortread_qc                = true
+    shortread_qc_mergepairs             = true
+    perform_shortread_complexityfilter  = false
+    save_complexityfiltered_reads       = false
 
-    perform_longread_qc = true
-    perform_shortread_hostremoval = true
-    perform_longread_hostremoval = true
-    save_hostremoval_index = true
-    save_hostremoval_bam = true
-    save_hostremoval_unmapped = true
+    perform_longread_qc                 = true
+    perform_shortread_hostremoval       = true
+    perform_longread_hostremoval        = true
+    save_hostremoval_index              = false
+    save_hostremoval_bam                = false
+    save_hostremoval_unmapped           = false
 
-    perform_runmerging = true
-    save_runmerged_reads = true
+    perform_runmerging                  = true
+    save_runmerged_reads                = false
 
-    run_centrifuge = true
-    centrifuge_save_reads = true
+    run_centrifuge                      = true
+    centrifuge_save_reads               = false
 
-    run_diamond = true
+    run_diamond                         = true
 
-    run_kaiju = true
+    run_kaiju                           = true
 
-    run_kraken2 = true
-    kraken2_save_reads = true
-    kraken2_save_readclassification = true
-    kraken2_save_minimizers  = true
+    run_kraken2                         = true
+    kraken2_save_reads                  = false
+    kraken2_save_readclassification     = false
+    kraken2_save_minimizers             = false
 
-    run_krakenuniq = true
-    krakenuniq_save_reads = true
-    krakenuniq_save_readclassifications = true
+    run_krakenuniq                      = true
+    krakenuniq_save_reads               = false
+    krakenuniq_save_readclassifications = false
 
-    run_bracken = true
-
-    run_malt = true
-    malt_save_reads = true
-    malt_generate_megansummary = true
-
-    run_metaphlan3 = true
-
-    run_motus = true
-    motus_save_mgc_read_counts = true
-
-    run_profile_standardisation = true
-    run_krona = true
+    run_bracken                         = true
+        
+    run_malt                            = true
+    malt_save_reads                     = false
+    malt_generate_megansummary          = true
+        
+    run_metaphlan3                      = true
+        
+    run_motus                           = true
+    motus_save_mgc_read_counts          = true
+        
+    run_profile_standardisation         = true
+    run_krona                           = true
 }
 
 cleanup = true


### PR DESCRIPTION
Re: https://nfcore.slack.com/archives/CTY8L26C8/p1679040181299829?thread_ts=1678923529.023299&cid=CTY8L26C8 and https://nfcore.slack.com/archives/DEL52B0U8/p1679040013345729

Hopefully if I can get it to work, in teh future we can have a system to save the final reads that go into preprocessing a la the diea at the bottom fo #262, and save only those

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
