### PR TITLE
No need to check outdir for existence - Nextflow can create it on demand

### DIFF
--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -17,7 +17,7 @@ WorkflowTaxprofiler.initialise(params, log)
 
 // Check input path parameters to see if they exist
 def checkPathParamList = [ params.input, params.genome, params.databases,
-                            params.outdir, params.longread_hostremoval_index,
+                            params.longread_hostremoval_index,
                             params.hostremoval_reference, params.shortread_hostremoval_index,
                             params.multiqc_config, params.shortread_qc_adapterlist,
                             params.krona_taxonomy_directory,


### PR DESCRIPTION
At the moment, we check the `outdir` parameter for existence, but many users will want to write results to a directory that doesn't currently exist. Removing `params.outdir` from the `checkPathParamList` will allow users to write to new directories.

## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
