### PR TITLE
Remove meta clone everywhere for improved resume stability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#304](https://github.com/nf-core/taxprofiler/pull/304) Correct mistake in kaiju2table documentation, only single rank can be supplied (♥ to @artur-matysik for reporting, fix by @jfy133)
 - [#307](https://github.com/nf-core/taxprofiler/pull/307) Fix databases being sometimes associated with the wrong tool (e.g. Kaiju) (fix by @jfy133)
 - [#313](https://github.com/nf-core/taxprofiler/pull/304) Fix pipeline not providing error when database sheet does not have a header (♥ to @noah472 for reporting, fix by @jfy133)
-- Improved meta map stability for more robust pipeline resuming
+- Improved meta map stability for more robust pipeline resuming (fix by @jfy133)
 
 ### `Dependencies`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#304](https://github.com/nf-core/taxprofiler/pull/304) Correct mistake in kaiju2table documentation, only single rank can be supplied (♥ to @artur-matysik for reporting, fix by @jfy133)
 - [#307](https://github.com/nf-core/taxprofiler/pull/307) Fix databases being sometimes associated with the wrong tool (e.g. Kaiju) (fix by @jfy133)
 - [#313](https://github.com/nf-core/taxprofiler/pull/304) Fix pipeline not providing error when database sheet does not have a header (♥ to @noah472 for reporting, fix by @jfy133)
+- Improved meta map stability for more robust pipeline resuming
 
 ### `Dependencies`
 

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -75,16 +75,21 @@ workflow PROFILING {
                     // as we don't run run on a per-sample basis due to huge datbaases
                     // so all samples are in one run and so sample-specific metadata
                     // unnecessary. Set as database name to prevent `null` job ID and prefix.
-                    def temp_meta = [ id: meta.db_name ]
+                    def temp_meta = [ id: db_meta.db_name ]
 
                     // Extend database parameters to specify whether to save alignments or not
-                    def new_db_meta = db_meta.clone()
                     def sam_format = params.malt_save_reads ? ' --alignments ./ -za false' : ""
+
+                    def db_meta_keys = db_meta.keySet()
+                    def new_db_meta = db_meta.subMap(db_meta_keys)
                     new_db_meta.db_params = db_meta.db_params + sam_format
 
                     // Combine reduced sample metadata with updated database parameters metadata,
                     // make sure id is db_name for publishing purposes.
                     def new_meta = temp_meta + new_db_meta
+
+                    println(new_db_meta)
+
                     new_meta.id = new_meta.db_name
 
                     [ new_meta, reads, db ]
@@ -106,9 +111,8 @@ workflow PROFILING {
                                             // re-extract meta from file names, use filename without rma to
                                             // ensure we keep paired-end information in downstream filenames
                                             // when no pair-merging
-                                            def meta_new = meta.clone()
-                                            meta_new['db_name'] = meta.id
-                                            meta_new['id'] = rma.baseName
+                                            def meta_new = meta + [db_name: meta.id, id: rma.baseName]
+
                                         [ meta_new, rma ]
                                 }
 
@@ -127,9 +131,10 @@ workflow PROFILING {
         ch_input_for_kraken2 = ch_input_for_profiling.kraken2
                                 .map {
                                     meta, reads, db_meta, db ->
-                                        def db_meta_new = db_meta.clone()
+                                        def db_meta_keys = db_meta.keySet()
+                                        def db_meta_new = db_meta.subMap(db_meta_keys)
 
-                                        // Only take second element if one exists
+                                        // Only take first element if one exists
                                         def parsed_params = db_meta_new['db_params'].split(";")
                                         if ( parsed_params.size() == 2 ) {
                                             db_meta_new['db_params'] = parsed_params[0]
@@ -186,7 +191,8 @@ workflow PROFILING {
             .map {
 
                 key, meta, reads, db_meta, db ->
-                    def db_meta_new = db_meta.clone()
+                    def db_meta_keys = db_meta.keySet()
+                    def db_meta_new = db_meta.subMap(db_meta_keys)
 
                     // Have to pick second element if using bracken, as first element
                     // contains kraken parameters

--- a/subworkflows/local/shortread_fastp.nf
+++ b/subworkflows/local/shortread_fastp.nf
@@ -28,8 +28,7 @@ workflow SHORTREAD_FASTP {
         ch_fastp_reads_prepped_pe = FASTP_PAIRED.out.reads_merged
                                         .map {
                                             meta, reads ->
-                                                def meta_new = meta.clone()
-                                                meta_new['single_end'] = true
+                                                def meta_new = meta + [single_end: true]
                                                 [ meta_new, [ reads ].flatten() ]
                                         }
 

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -209,8 +209,7 @@ workflow TAXPROFILER {
             .mix( ch_longreads_hostremoved )
             .map {
                 meta, reads ->
-                    def meta_new = meta.clone()
-                    meta_new.remove('run_accession')
+                    def meta_new = meta - meta.subMap('run_accession')
                     [ meta_new, reads ]
             }
             .groupTuple()


### PR DESCRIPTION
Because of this: https://www.youtube.com/watch?v=A357C-ux6Dw&t=879s

meta.clone() only does a shallow clone, thus end edits to that will be propogated across _all_ sister channels using the same meta.map. Switching to `subMap` operations results in deep/independent maps (even if identical)

I've tested all channels before and after with dumps to make sure they look OK :+1: (i.e., lane merging, fastp, malt, kraken/bracken)

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
