### PR TITLE
Fix missing tag in MQC dynamic methods section and missing KMCP in taxpasta ouput

### DIFF
--- a/conf/test_full.config
+++ b/conf/test_full.config
@@ -36,6 +36,8 @@ params {
     perform_runmerging                  = true
     save_runmerged_reads                = false
 
+    save_analysis_ready_fastqs          = true
+
     run_centrifuge                      = true
     centrifuge_save_reads               = false
 
@@ -53,6 +55,7 @@ params {
     krakenuniq_save_readclassifications = false
 
     run_bracken                         = true
+
     run_malt                            = true
     malt_save_reads                     = false
     malt_generate_megansummary          = true

--- a/lib/WorkflowTaxprofiler.groovy
+++ b/lib/WorkflowTaxprofiler.groovy
@@ -100,7 +100,7 @@ class WorkflowTaxprofiler {
                 params.run_kaiju      ? "Kaiju (Menzel et al. 2016)," : "",
                 params.run_motus      ? "mOTUs (Ruscheweyh et al. 2022)," : "",
                 params.run_ganon      ? "ganon (Piro et al. 2020)" : "",
-                params.run_kmcp       ? "kmcp (Shen et al. 2023)" : "",
+                params.run_kmcp       ? "KMCP (Shen et al. 2023)" : "",
                 "."
             ].join(' ').trim()
 
@@ -200,7 +200,7 @@ class WorkflowTaxprofiler {
             text_classification,
             params.run_krona                          ? text_visualisation : "",
             params.run_profile_standardisation        ? text_postprocessing : "",
-            "<li>Ewels, P., Magnusson, M., Lundin, S., & Käller, M. (2016). MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics , 32(19), 3047–3048. <a href=\"https:/doi.org/10.1093/bioinformatics/btw354\">10.1093/bioinformatics/btw354.</li>"
+            "<li>Ewels, P., Magnusson, M., Lundin, S., & Käller, M. (2016). MultiQC: summarize analysis results for multiple tools and samples in a single report. Bioinformatics , 32(19), 3047–3048. <a href=\"https:/doi.org/10.1093/bioinformatics/btw354\">10.1093/bioinformatics/btw354.</a></li>"
         ].join(' ').trim().replaceAll("[,|.] +\\.", ".")
 
         return reference_text

--- a/subworkflows/local/standardisation_profiles.nf
+++ b/subworkflows/local/standardisation_profiles.nf
@@ -49,12 +49,6 @@ workflow STANDARDISATION_PROFILES {
 
     //Taxpasta standardisation
     ch_prepare_for_taxpasta = profiles
-                            .filter {
-                                meta, report ->
-                                // TODO: add tool to taxpasta
-                                    if ( meta['tool'] == 'kmcp' ) log.warn "[nf-core/taxprofiler] kmcp is not yet supported in Taxpasta. Skipping kmcp profile for sample ${meta.id}."
-                                    meta['tool'] != 'kmcp'
-                             }
                             .map {
                                     meta, profile ->
                                         def meta_new = [:]


### PR DESCRIPTION
- missing tag Meant everything underneath was still the link
- Fxed typo kmcp in docs
- KMCP output now mixed in taxpasta
- Added additional 'useful' output file to full test (final reads for profiling) 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
