### PR TITLE
Fix the input of centrifuge_kreport

### DIFF
--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -264,7 +264,7 @@ workflow PROFILING {
                                                 .filter { meta, db -> meta.tool == 'centrifuge' }
                                                 .map { meta, db -> [meta.db_name, meta, db] }
 
-        ch_input_for_centrifuge_kreport = combineProfilesWithDatabase(CENTRIFUGE_CENTRIFUGE.out.report, ch_database_for_centrifugekreport)
+        ch_input_for_centrifuge_kreport = combineProfilesWithDatabase(CENTRIFUGE_CENTRIFUGE.out.results, ch_database_for_centrifugekreport)
 
         // Generate profile
         CENTRIFUGE_KREPORT (ch_input_for_centrifuge_kreport.profile, ch_input_for_centrifuge_kreport.db)


### PR DESCRIPTION
<!--
# nf-core/taxprofiler pull request

Many thanks for contributing to nf-core/taxprofiler!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
-->

In profiling.nf, correct the input for `CENTRIFUGE_KREPORT` to specify the `results` file rather than the `report` file.

**The output of centrifuge_kreport when using the report file (old code):** The assgined reads counts are not correct

<img width="872" alt="image" src="https://github.com/nf-core/taxprofiler/assets/64467552/81764b0a-3bde-43ad-b067-d42c4cc30455">

**The output of centrifuge_kreport when using the results file (corrected one):**
<img width="869" alt="image" src="https://github.com/nf-core/taxprofiler/assets/64467552/b3968ae3-cfef-4298-b3bc-c5c3e65eb090">


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
