### PR TITLE
`Sourmash` profiler [DO NOT MERGE YET]

### DIFF
--- a/conf/test_sourmash.config
+++ b/conf/test_sourmash.config
@@ -1,0 +1,63 @@
+/*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Nextflow config file for running minimal tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+    Defines input files and everything required to run a fast and simple pipeline test.
+
+    Use as follows:
+        nextflow run nf-core/taxprofiler -profile test,<docker/singularity> --outdir <OUTDIR>
+
+----------------------------------------------------------------------------------------
+*/
+
+//
+// Separate test for sourmash
+//
+
+params {
+    config_profile_name        = 'Test profile'
+    config_profile_description = 'Minimal test to check sourmash function'
+
+    // Limit resources so that this can run on GitHub Actions
+    max_cpus   = 2
+    max_memory = '6.GB'
+    max_time   = '6.h'
+
+    // Input data
+    input                                 = 'https://github.com/nf-core/test-datasets/raw/taxprofiler/samplesheet.csv'
+    databases                             = 'https://raw.githubusercontent.com/nf-core/test-datasets/taxprofiler/database_v1.1.csv'
+    perform_shortread_qc                  = false
+    perform_longread_qc                   = false
+    perform_shortread_complexityfilter    = false
+    perform_shortread_hostremoval         = false
+    perform_longread_hostremoval          = false
+    perform_runmerging                    = false
+    hostremoval_reference                 = 'https://raw.githubusercontent.com/nf-core/test-datasets/modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                             = false
+    run_kraken2                           = false
+    run_bracken                           = false
+    run_malt                              = false
+    run_metaphlan                         = false
+    run_centrifuge                        = false
+    run_diamond                           = false
+    run_krakenuniq                        = false
+    run_motus                             = false
+    run_ganon                             = false
+    run_kmcp                              = false
+    kmcp_mode                             = 0
+    run_sourmash                          = true
+}
+
+
+process {
+    withName: SOURMASH_SKETCH {
+        ext.args = "dna --param-string 'k=31,scaled=10,noabund'"
+    }
+
+    withName: SOURMASH_GATHER {
+        ext.args = "--threshold-bp 0"
+    }
+
+}
+
+

--- a/lib/WorkflowTaxprofiler.groovy
+++ b/lib/WorkflowTaxprofiler.groovy
@@ -102,6 +102,7 @@ class WorkflowTaxprofiler {
                 params.run_motus      ? "mOTUs (Ruscheweyh et al. 2022)," : "",
                 params.run_ganon      ? "ganon (Piro et al. 2020)" : "",
                 params.run_kmcp       ? "KMCP (Shen et al. 2023)" : "",
+                params.run_sourmash   ? "sourmash (Brown & Irber 2016)" : "",
                 "."
             ].join(' ').trim()
 
@@ -174,6 +175,7 @@ class WorkflowTaxprofiler {
                 params.run_motus      ? "<li>Ruscheweyh, H.-J., Milanese, A., Paoli, L., Karcher, N., Clayssen, Q., Keller, M. I., Wirbel, J., Bork, P., Mende, D. R., Zeller, G., & Sunagawa, S. (2022). Cultivation-independent genomes greatly expand taxonomic-profiling capabilities of mOTUs across various environments. Microbiome, 10(1), 212. <a href=\"https://doi.org/10.1186/s40168-022-01410-z\">10.1186/s40168-022-01410-z</a></li>" : "",
                 params.run_ganon      ? "<li>Piro, V. C., Dadi, T. H., Seiler, E., Reinert, K., & Renard, B. Y. (2020). Ganon: Precise metagenomics classification against large and up-to-date sets of reference sequences. Bioinformatics (Oxford, England), 36(Suppl_1), i12–i20. <a href=\"https://doi.org/10.1093/bioinformatics/btaa458\">10.1093/bioinformatics/btaa458</a></li>" : "",
                 params.run_kmcp       ? "<li>Shen, W., Xiang, H., Huang, T., Tang, H., Peng, M., Cai, D., Hu, P., & Ren, H. (2023). KMCP: accurate metagenomic profiling of both prokaryotic and viral populations by pseudo-mapping. Bioinformatics (Oxford, England), 39(1). <a href=\"https://doi.org/10.1093/bioinformatics/btac845\">10.1093/bioinformatics/btac845</a></li>" : "",
+                params.run_sourmash   ? "<li>Brown, T., & Irber, L. (2016).  sourmash: a library for MinHash sketching of DNA. Journal of Open Source Software, 1(5). <a href=\"https://doi.org/10.21105/joss.00027\">10.21105/joss.00027</a></li>" : "",
             ].join(' ').trim()
 
             def text_visualisation = [

--- a/modules.json
+++ b/modules.json
@@ -232,6 +232,21 @@
                         "git_sha": "3ffae3598260a99e8db3207dead9f73f87f90d1f",
                         "installed_by": ["modules"]
                     },
+                    "sourmash/gather": {
+                        "branch": "master",
+                        "git_sha": "33f66e0b2612df417ba94e89ce4c3770258d674b",
+                        "installed_by": ["modules"]
+                    },
+                    "sourmash/sketch": {
+                        "branch": "master",
+                        "git_sha": "33f66e0b2612df417ba94e89ce4c3770258d674b",
+                        "installed_by": ["modules"]
+                    },
+                    "sourmash/taxannotate": {
+                        "branch": "master",
+                        "git_sha": "33f66e0b2612df417ba94e89ce4c3770258d674b",
+                        "installed_by": ["modules"]
+                    },
                     "taxpasta/merge": {
                         "branch": "master",
                         "git_sha": "48019785051ba491e82dce910273c2eca61bd5b7",

--- a/modules/nf-core/sourmash/gather/main.nf
+++ b/modules/nf-core/sourmash/gather/main.nf
@@ -1,0 +1,53 @@
+process SOURMASH_GATHER {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::sourmash=4.8.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sourmash:4.8.4--hdfd78af_0':
+        'biocontainers/sourmash:4.8.4--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(signature)
+    path(database)
+    val save_unassigned
+    val save_matches_sig
+    val save_prefetch
+    val save_prefetch_csv
+
+    output:
+    tuple val(meta), path('*.csv.gz')             , optional:true, emit: result
+    tuple val(meta), path('*_unassigned.sig.zip') , optional:true, emit: unassigned
+    tuple val(meta), path('*_matches.sig.zip')    , optional:true, emit: matches
+    tuple val(meta), path('*_prefetch.sig.zip')   , optional:true, emit: prefetch
+    tuple val(meta), path('*_prefetch.csv.gz')    , optional:true, emit: prefetchcsv
+    path "versions.yml"                           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def unassigned  = save_unassigned   ? "--output-unassigned ${prefix}_unassigned.sig.zip" : ''
+    def matches     = save_matches_sig  ? "--save-matches ${prefix}_matches.sig.zip"         : ''
+    def prefetch    = save_prefetch     ? "--save-prefetch ${prefix}_prefetch.sig.zip"       : ''
+    def prefetchcsv = save_prefetch_csv ? "--save-prefetch-csv ${prefix}_prefetch.csv.gz"    : ''
+
+    """
+    sourmash gather \\
+        $args \\
+        --output ${prefix}.csv.gz \\
+        ${unassigned} \\
+        ${matches} \\
+        ${prefetch} \\
+        ${prefetchcsv} \\
+        ${signature} \\
+        ${database}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sourmash: \$(echo \$(sourmash --version 2>&1) | sed 's/^sourmash //' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/sourmash/gather/meta.yml
+++ b/modules/nf-core/sourmash/gather/meta.yml
@@ -1,0 +1,93 @@
+name: "sourmash_gather"
+description: Search a metagenome sourmash signature against one or many reference databases and return the minimum set of genomes that contain the k-mers in the metagenome.
+keywords:
+  - FracMinHash sketch
+  - signature
+  - kmer
+  - containment
+  - sourmash
+  - genomics
+  - metagenomics
+  - taxonomic classification
+  - taxonomic profiling
+tools:
+  - "sourmash":
+      description: Compute and compare FracMinHash signatures for DNA data sets.
+      homepage: https://sourmash.readthedocs.io/
+      documentation: https://sourmash.readthedocs.io/
+      tool_dev_url: https://github.com/sourmash-bio/sourmash
+      doi: "10.21105/joss.00027"
+      licence: ["BSD-3-clause"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - signature:
+      type: file
+      description: File containing signatures (hash sketches) of a sample
+      pattern: "*.{sig}"
+  - db:
+      type: file
+      description: Sourmash database (a list of signatures, SBTs, or signature zip files)
+  - save_unassigned:
+      type: boolean
+      description: |
+        If true, output will contain a file that is a sourmash signature containing the unassigned hashes from the query
+  - save_matches_sig:
+      type: boolean
+      description: |
+        If true, output will contain a file that is a sourmash signature composed of the FracMinHash sketches that were matched in the database and that matched the query
+  - save_prefetch:
+      type: boolean
+      description: |
+        If true, output will contain a file with all prefetch-matched signatures from the database
+  - save_prefetch_csv:
+      type: boolean
+      description: |
+        If true, output will contain a csv file with the names of all prefetch-matched signatures
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - result:
+      type: file
+      description: |
+        Table with signatures classified as belonging to any of the genomes
+        in the sourmash database(s).
+      pattern: "*{csv.gz}"
+  - matches:
+      type: file
+      description: |
+        A signature containing FracMinHash sketches of genomes
+        in the sourmash database.
+      pattern: "*{sig.zip}"
+  - unassigned:
+      type: file
+      description: |
+        A FracMinHash sketch containing hashes (k-mers) that did not match to any of the genomes
+        in the sourmash database(s).
+      pattern: "*{sig.zip}"
+  - prefetch:
+      type: file
+      description: |
+        All prefetch-matched signatures from the database.
+      pattern: "*{sig.zip}"
+  - prefetchcsv:
+      type: file
+      description: |
+        The names of all prefetch-matched signatures from the database in CSV format.
+      pattern: "*{csv.gz}"
+
+authors:
+  - "@vmikk"
+  - "@taylorreiter"

--- a/modules/nf-core/sourmash/sketch/main.nf
+++ b/modules/nf-core/sourmash/sketch/main.nf
@@ -1,0 +1,36 @@
+process SOURMASH_SKETCH {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::sourmash=4.8.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sourmash:4.8.4--hdfd78af_0':
+        'biocontainers/sourmash:4.8.4--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(sequence)
+
+    output:
+    tuple val(meta), path("*.sig"), emit: signatures
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    // required defaults for the tool to run, but can be overridden
+    def args = task.ext.args ?: "dna --param-string 'scaled=1000,k=21,k=31,k=51,abund'"
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    sourmash sketch \\
+        $args \\
+        --merge '${prefix}' \\
+        --output '${prefix}.sig' \\
+        $sequence
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sourmash: \$(echo \$(sourmash --version 2>&1) | sed 's/^sourmash //' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/sourmash/sketch/meta.yml
+++ b/modules/nf-core/sourmash/sketch/meta.yml
@@ -1,0 +1,47 @@
+name: sourmash_sketch
+description: Create a signature (a group of FracMinHash sketches) of a sequence using sourmash
+keywords:
+  - hash sketch
+  - sourmash
+  - genomics
+  - metagenomics
+  - taxonomic classification
+  - taxonomic profiling
+  - kmer
+tools:
+  - sourmash:
+      description: Compute and compare FracMinHash signatures for DNA and protein data sets.
+      homepage: https://sourmash.readthedocs.io/
+      documentation: https://sourmash.readthedocs.io/
+      tool_dev_url: https://github.com/sourmash-bio/sourmash
+      doi: "10.21105/joss.00027"
+      licence: ["BSD-3-clause"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - sequence:
+      type: file
+      description: FASTA or FASTQ file containing (genomic, transcriptomic, or proteomic) sequence data
+      pattern: "*.{fna,fa,fasta,fastq,fq,faa}.gz"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - signatures:
+      type: file
+      description: FracMinHash signature of the given sequence
+      pattern: "*.{sig}"
+
+authors:
+  - "@Midnighter"

--- a/modules/nf-core/sourmash/taxannotate/main.nf
+++ b/modules/nf-core/sourmash/taxannotate/main.nf
@@ -1,0 +1,39 @@
+process SOURMASH_TAXANNOTATE {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "bioconda::sourmash=4.8.4"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/sourmash:4.8.4--hdfd78af_0':
+        'biocontainers/sourmash:4.8.4--hdfd78af_0' }"
+
+    input:
+    tuple val(meta), path(gather_results)
+    path(taxonomy)
+
+    output:
+    tuple val(meta), path("*.with-lineages.csv.gz"), emit: result
+    path "versions.yml"                            , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    """
+    sourmash \\
+        tax annotate \
+        $args \\
+        --gather-csv ${gather_results} \\
+        --taxonomy ${taxonomy} \\
+        --output-dir "."
+
+    ## Compress output
+    gzip --no-name *.with-lineages.csv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        sourmash: \$(echo \$(sourmash --version 2>&1) | sed 's/^sourmash //' )
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/sourmash/taxannotate/meta.yml
+++ b/modules/nf-core/sourmash/taxannotate/meta.yml
@@ -1,0 +1,59 @@
+name: "sourmash_taxannotate"
+description: Annotate list of metagenome members (based on sourmash signature matches) with taxonomic information.
+keywords:
+  - fracminhash sketch
+  - signature
+  - kmer
+  - containment
+  - sourmash
+  - genomics
+  - metagenomics
+  - taxonomic classification
+  - taxonomic profiling
+tools:
+  - "sourmash":
+      description: Compute and compare FracMinHash signatures for DNA data sets.
+      homepage: https://sourmash.readthedocs.io/
+      documentation: https://sourmash.readthedocs.io/
+      tool_dev_url: https://github.com/sourmash-bio/sourmash
+      doi: "10.21105/joss.00027"
+      licence: ["BSD-3-clause"]
+
+## Description of all of the variables used as input
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - gather_results:
+      type: file
+      description: |
+        Mandatory table with signatures classified as belonging to any of the genomes
+        in the sourmash database(s), result of `sourmash gather` command.
+  - taxonomy:
+      type: file
+      description: One or more databases with lineages (in CSV format, Mandatory)
+
+## Description of all of the variables used as output
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - result:
+      type: file
+      description: |
+        Table with signatures classified as belonging to any of the genomes
+        in the sourmash database(s) with an additional 'lineage' column
+        containing the taxonomic information for each database match.
+      pattern: "*{csv.gz}"
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+
+authors:
+  - "@vmikk"
+  - "@taylorreiter"

--- a/nextflow.config
+++ b/nextflow.config
@@ -168,6 +168,9 @@ params {
     ganon_report_maxcount           = 0
     ganon_save_readclassifications  = false
 
+    // sourmash
+    run_sourmash                    = false
+
     // krona
     run_krona                  = false
     krona_taxonomy_directory   = null
@@ -306,7 +309,8 @@ profiles {
     test_adapterremoval     { includeConfig 'conf/test_adapterremoval.config' }
     test_bbduk              { includeConfig 'conf/test_bbduk.config' }
     test_prinseqplusplus    { includeConfig 'conf/test_prinseqplusplus.config' }
-
+    test_kmcp               { includeConfig 'conf/test_kmcp.config' }
+    test_sourmash           { includeConfig 'conf/test_sourmash.config' }
 }
 
 // Set default registry for Apptainer, Docker, Podman and Singularity independent of -profile

--- a/subworkflows/local/db_check.nf
+++ b/subworkflows/local/db_check.nf
@@ -79,7 +79,7 @@ def validate_db_rows(LinkedHashMap row) {
     if ( !row.keySet().containsAll(expected_headers) ) error("[nf-core/taxprofiler] ERROR: Invalid database input sheet - malformed column names. Please check input TSV. Column names should be: ${expected_headers.join(", ")}")
 
     // valid tools specified
-    def expected_tools = [ "bracken", "centrifuge", "diamond", "ganon", "kaiju", "kmcp", "kraken2", "krakenuniq", "malt", "metaphlan", "motus" ]
+    def expected_tools = [ "bracken", "centrifuge", "diamond", "ganon", "kaiju", "kmcp", "kraken2", "krakenuniq", "malt", "metaphlan", "motus", "sourmash" ]
 
     if ( !expected_tools.contains(row.tool) ) error("[nf-core/taxprofiler] ERROR: Invalid tool name. Please see documentation for all supported profilers. Error in: ${row}")
 

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -81,6 +81,7 @@ workflow PROFILING {
                 motus: it[2]['tool'] == 'motus'
                 kmcp: it[2]['tool'] == 'kmcp'
                 ganon: it[2]['tool'] == 'ganon'
+                sourmash:  it[2]['tool'] == 'sourmash'
                 unknown: true
             }
 

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -19,6 +19,9 @@ include { KMCP_SEARCH                                   } from '../../modules/nf
 include { KMCP_PROFILE                                  } from '../../modules/nf-core/kmcp/profile/main'
 include { GANON_CLASSIFY                                } from '../../modules/nf-core/ganon/classify/main'
 include { GANON_REPORT                                  } from '../../modules/nf-core/ganon/report/main'
+include { SOURMASH_SKETCH                               } from '../../modules/nf-core/sourmash/sketch/main'
+include { SOURMASH_GATHER                               } from '../../modules/nf-core/sourmash/gather/main'
+include { SOURMASH_TAXANNOTATE                          } from '../../modules/nf-core/sourmash/taxannotate/main'
 
 
 // Custom Functions

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -538,6 +538,10 @@ workflow PROFILING {
             ch_input_for_sourmash_gather.tax
             )
 
+        ch_versions      = ch_versions.mix( SOURMASH_TAXANNOTATE.out.versions.first() )
+        ch_raw_profiles  = ch_raw_profiles.mix( SOURMASH_TAXANNOTATE.out.result )
+        ch_multiqc_files = ch_multiqc_files.mix( SOURMASH_TAXANNOTATE.out.result )
+
     }
 
 

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -515,8 +515,8 @@ workflow PROFILING {
                                     it ->
                                         signatures: [ it[3], it[2] ]
                                         db_path: it[4]
-                                        db:  it[4] + "/*.zip"
-                                        tax: it[4] + "/sourmash-taxonomy.csv"
+                                        db:  it[4] + "/sourmash-db.zip"
+                                        tax: it[4] + "/lineages.csv.gz"
                                 }
 
         // ch_input_for_sourmash_gather.signatures.view()

--- a/subworkflows/local/profiling.nf
+++ b/subworkflows/local/profiling.nf
@@ -512,11 +512,19 @@ workflow PROFILING {
                                     it -> [ it[0].sample, it[0], it[1] ]
                                 }.join(sourmash_sample_database)
                                 .multiMap  {
-                                    it ->
-                                        signatures: [ it[3], it[2] ]
-                                        db_path: it[4]
-                                        db:  it[4] + "/sourmash-db.zip"
-                                        tax: it[4] + "/lineages.csv.gz"
+                                    input ->
+
+                                        // Get the database file names from the channel (e.g., ZIP and CSV.GZ)
+                                        def find_db  = []
+                                        def find_tax = []
+
+                                        input.eachFileMatch( ~/.*\.zip$/ )        { find_db << it  }
+                                        input.eachFileMatch( ~/.*\.csv(\.gz)?$/ ) { find_tax << it }
+
+                                        signatures: [ input[3], input[2] ]
+                                        db_path: input[4]
+                                        db:  [find_db]
+                                        tax: [find_tax]
                                 }
 
         // ch_input_for_sourmash_gather.signatures.view()


### PR DESCRIPTION
This PR adds `sourmash` as an additional profiler.
Related to https://github.com/nf-core/taxprofiler/issues/112

NOTES:
1. Database
Sourmash supports several [types of databases](https://sourmash.readthedocs.io/en/latest/databases.html#types-of-databases).
For taxprofiler, I propose to use a single ZIP file containing signatures, but the database also requires a CSV file with taxonomic information (gzip-compessed csv is also supported). So the tar file with database should contain two files:
```
test-db-sourmash
├── sourmash-db.zip
└── lineages.csv.gz
```
For now, file names are hardcoded .

2. As a first step, sourmash creates FracMinHash sketches (signatures) for each sample. 
This step is independent of the database, so we need to do sketching only once. Therefore, I removed the database from the input channel (`ch_input_for_profiling.sourmash.map`). Otherwise, it will perform independent sketching for each database provided and we will have lots of duplicated samples, isn't it?

4. Sourmash can create [4 types of signatures](https://sourmash.readthedocs.io/en/latest/command-line.html#sourmash-sketch-make-sourmash-signatures-from-sequence-data): DNA, protein, protein translated from DNA, and signatures based on CSV file with locations to genomes/proteomes.
The `sourmash/sketch` module is written to support all these input types. Therefore, it is required to pass extra args to the process. The esieast way is to specify it in the config, e.g.:
```
process {
    withName: SOURMASH_SKETCH {
        ext.args = "dna --param-string 'k=31,scaled=1000,noabund'"
    }
}
```
, where the first word in `ext.args` should be `dna`, `protein`, `translate`, or `fromfile`.



## TO DO list
- [ ] upload test dataset to nf-core/test-datasets#taxprofiler branch
- [ ] ...

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [x] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
