### PR TITLE
Update multiqc, fastqc, filtlong, adapterremoval, dumpsoftwareversions

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -7,7 +7,7 @@
                 "nf-core": {
                     "adapterremoval": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "5add1e8e11af620c779462936ce8bbcc1abcef2d",
                         "installed_by": ["modules"]
                     },
                     "bbmap/bbduk": {
@@ -52,7 +52,7 @@
                     },
                     "custom/dumpsoftwareversions": {
                         "branch": "master",
-                        "git_sha": "05c280924b6c768d484c7c443dad5e605c4ff4b4",
+                        "git_sha": "8ec825f465b9c17f9d83000022995b4f7de6fe93",
                         "installed_by": ["modules"]
                     },
                     "diamond/blastx": {
@@ -73,12 +73,12 @@
                     },
                     "fastqc": {
                         "branch": "master",
-                        "git_sha": "bd8092b67b5103bdd52e300f75889442275c3117",
+                        "git_sha": "617777a807a1770f73deb38c80004bac06807eef",
                         "installed_by": ["modules"]
                     },
                     "filtlong": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "b4c8ac68ffcdabac3f63aaa5e7420b175e1d8d76",
                         "installed_by": ["modules"]
                     },
                     "ganon/classify": {
@@ -198,7 +198,7 @@
                     },
                     "multiqc": {
                         "branch": "master",
-                        "git_sha": "a6e11ac655e744f7ebc724be669dd568ffdc0e80",
+                        "git_sha": "8ec825f465b9c17f9d83000022995b4f7de6fe93",
                         "installed_by": ["modules"]
                     },
                     "porechop/porechop": {

--- a/modules/nf-core/adapterremoval/environment.yml
+++ b/modules/nf-core/adapterremoval/environment.yml
@@ -1,0 +1,7 @@
+name: adapterremoval
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::adapterremoval=2.3.2

--- a/modules/nf-core/adapterremoval/main.nf
+++ b/modules/nf-core/adapterremoval/main.nf
@@ -2,7 +2,7 @@ process ADAPTERREMOVAL {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::adapterremoval=2.3.2"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/adapterremoval:2.3.2--hb7ba0dd_0' :
         'biocontainers/adapterremoval:2.3.2--hb7ba0dd_0' }"

--- a/modules/nf-core/adapterremoval/meta.yml
+++ b/modules/nf-core/adapterremoval/meta.yml
@@ -11,7 +11,6 @@ tools:
       homepage: https://github.com/MikkelSchubert/adapterremoval
       documentation: https://adapterremoval.readthedocs.io
       licence: ["GPL v3"]
-
 input:
   - meta:
       type: map
@@ -26,17 +25,8 @@ input:
       pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
   - adapterlist:
       type: file
-      description: Optional text file containing list of adapters to look for for removal
-        with one adapter per line. Otherwise will look for default adapters (see
-        AdapterRemoval man page), or can be modified to remove user-specified
-        adapters via ext.args.
-
+      description: Optional text file containing list of adapters to look for for removal with one adapter per line. Otherwise will look for default adapters (see AdapterRemoval man page), or can be modified to remove user-specified adapters via ext.args.
 output:
-  - meta:
-      type: map
-      description: |
-        Groovy Map containing sample information
-        e.g. [ id:'test', single_end:false ]
   - singles_truncated:
       type: file
       description: |
@@ -50,20 +40,13 @@ output:
         Adapter trimmed FastQ files of reads that did not pass filtering
         thresholds.
       pattern: "*.discarded.fastq.gz"
-  - pair1_truncated:
+  - paired_truncated:
       type: file
       description: |
-        Adapter trimmed R1 FastQ files of paired-end reads that did not merge
-        with their respective R2 pair due to long templates. The respective pair
-        is stored in 'pair2_truncated'.
-      pattern: "*.pair1.truncated.fastq.gz"
-  - pair2_truncated:
-      type: file
-      description: |
-        Adapter trimmed R2 FastQ files of paired-end reads that did not merge
-        with their respective R1 pair due to long templates. The respective pair
-        is stored in 'pair1_truncated'.
-      pattern: "*.pair2.truncated.fastq.gz"
+        Adapter trimmed R{1,2} FastQ files of paired-end reads that did not merge
+        with their respective R{1,2} pair due to long templates. The respective pair
+        is stored in 'pair{1,2}_truncated'.
+      pattern: "*.pair{1,2}.truncated.fastq.gz"
   - collapsed:
       type: file
       description: |
@@ -76,7 +59,12 @@ output:
         Collapsed FastQ of paired-end reads that successfully merged with their
         respective R1 pair and were trimmed of adapter due to sufficient overlap.
       pattern: "*.collapsed.truncated.fastq.gz"
-  - log:
+  - paired_interleaved:
+      type: file
+      description: |
+        Write paired-end reads to a single file, interleaving mate 1 and mate 2 reads
+      pattern: "*.paired.fastq.gz"
+  - settings:
       type: file
       description: AdapterRemoval log file
       pattern: "*.settings"
@@ -84,7 +72,9 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
-
 authors:
+  - "@maxibor"
+  - "@jfy133"
+maintainers:
   - "@maxibor"
   - "@jfy133"

--- a/modules/nf-core/adapterremoval/tests/main.nf.test
+++ b/modules/nf-core/adapterremoval/tests/main.nf.test
@@ -1,0 +1,120 @@
+nextflow_process {
+
+    name "Test Process ADAPTERREMOVAL"
+    script "../main.nf"
+    process "ADAPTERREMOVAL"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "adapterremoval"
+
+    test("single-end - sarscov2 - [fastq]") {
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:true, collapse:false ], // meta map                                                                             
+                            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)                                                  
+                ]      
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.singles_truncated,
+                                process.out.settings,
+                                process.out.versions).match() },
+            )
+        }
+    }
+
+    test("paired-end - sarscov2 - [fastq]") {
+
+        when {
+            process {
+                """
+                input[0] = [ 
+                            [ id:'test', single_end:false, collapse:false ], // meta map                                                                            
+                            [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),                                               
+                              file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]                                              
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.paired_truncated,
+                                process.out.settings,
+                                process.out.versions).match() },
+                { assert process.out.discarded } 
+            )
+        }
+
+    }
+
+    test("paired-end collapse - sarscov2 - [fastq]") {
+
+        options "--collapse"
+
+        when {
+            process {
+                """
+                input[0] = [ 
+                            [ id:'test', single_end:false ], // meta map                                                                                            
+                            [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),                                               
+                              file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]                                              
+                ]
+                input[1] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.paired_truncated,
+                                process.out.collapsed,
+                                process.out.settings,
+                                process.out.versions).match() },
+                { assert process.out.discarded }           
+            )
+        }
+
+    }
+
+    test("paired-end adapterlist - sarscov2 - [fastq]") {
+
+        when {
+            process {
+                """
+                input[0] = [ 
+                            [ id:'test', single_end:false, collapse:false ], // meta map                                                                            
+                            [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),                                               
+                              file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ]                                              
+                ]
+                input[1] = file("https://github.com/nf-core/test-datasets/raw/modules/data/delete_me/adapterremoval/adapterremoval_adapterlist.txt",           
+         checkIfExists: true)
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.paired_truncated,
+                                process.out.settings,
+                                process.out.versions).match() },
+                { assert process.out.discarded }                
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/adapterremoval/tests/main.nf.test.snap
+++ b/modules/nf-core/adapterremoval/tests/main.nf.test.snap
@@ -1,0 +1,124 @@
+{
+    "single-end - sarscov2 - [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "collapse": false
+                    },
+                    "test.truncated.fastq.gz:md5,119d1b1a0a71ca6e080ff7c53ee0b690"
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true,
+                        "collapse": false
+                    },
+                    "test.settings:md5,2fd3d5d703b63ba33a83021fccf25f77"
+                ]
+            ],
+            [
+                "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+            ]
+        ],
+        "timestamp": "2023-12-09T19:19:36.429445996"
+    },
+    "paired-end - sarscov2 - [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "collapse": false
+                    },
+                    [
+                        "test.pair1.truncated.fastq.gz:md5,e3da014fbb9b428e952c62e8f0fb6402",
+                        "test.pair2.truncated.fastq.gz:md5,2ebae722295ea66d84075a3b042e2b42"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "collapse": false
+                    },
+                    "test.settings:md5,b8a451d3981b327f3fdb44f40ba2d6d1"
+                ]
+            ],
+            [
+                "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+            ]
+        ],
+        "timestamp": "2023-12-09T19:19:42.88672676"
+    },
+    "paired-end collapse - sarscov2 - [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    [
+                        "test.pair1.truncated.fastq.gz:md5,e3da014fbb9b428e952c62e8f0fb6402",
+                        "test.pair2.truncated.fastq.gz:md5,2ebae722295ea66d84075a3b042e2b42"
+                    ]
+                ]
+            ],
+            [
+                
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.settings:md5,b8a451d3981b327f3fdb44f40ba2d6d1"
+                ]
+            ],
+            [
+                "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+            ]
+        ],
+        "timestamp": "2023-12-09T19:19:49.299792876"
+    },
+    "paired-end adapterlist - sarscov2 - [fastq]": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "collapse": false
+                    },
+                    [
+                        "test.pair1.truncated.fastq.gz:md5,e3da014fbb9b428e952c62e8f0fb6402",
+                        "test.pair2.truncated.fastq.gz:md5,2ebae722295ea66d84075a3b042e2b42"
+                    ]
+                ]
+            ],
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false,
+                        "collapse": false
+                    },
+                    "test.settings:md5,36d47d9b40dbc178167d1ae0274d18f3"
+                ]
+            ],
+            [
+                "versions.yml:md5,00bcc9f0b864b96eeee21bc11773ee67"
+            ]
+        ],
+        "timestamp": "2023-12-09T19:19:57.26567964"
+    }
+}

--- a/modules/nf-core/adapterremoval/tests/tags.yml
+++ b/modules/nf-core/adapterremoval/tests/tags.yml
@@ -1,0 +1,2 @@
+adapterremoval:
+  - "modules/nf-core/adapterremoval/**"

--- a/modules/nf-core/custom/dumpsoftwareversions/environment.yml
+++ b/modules/nf-core/custom/dumpsoftwareversions/environment.yml
@@ -1,0 +1,7 @@
+name: custom_dumpsoftwareversions
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::multiqc=1.19

--- a/modules/nf-core/custom/dumpsoftwareversions/main.nf
+++ b/modules/nf-core/custom/dumpsoftwareversions/main.nf
@@ -2,10 +2,10 @@ process CUSTOM_DUMPSOFTWAREVERSIONS {
     label 'process_single'
 
     // Requires `pyyaml` which does not have a dedicated container but is in the MultiQC container
-    conda "bioconda::multiqc=1.15"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.15--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.15--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.19--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.19--pyhdfd78af_0' }"
 
     input:
     path versions

--- a/modules/nf-core/custom/dumpsoftwareversions/meta.yml
+++ b/modules/nf-core/custom/dumpsoftwareversions/meta.yml
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: custom_dumpsoftwareversions
 description: Custom module used to dump software versions within the nf-core pipeline template
 keywords:
@@ -16,7 +16,6 @@ input:
       type: file
       description: YML file containing software versions
       pattern: "*.yml"
-
 output:
   - yml:
       type: file
@@ -30,7 +29,9 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
-
 authors:
+  - "@drpatelh"
+  - "@grst"
+maintainers:
   - "@drpatelh"
   - "@grst"

--- a/modules/nf-core/custom/dumpsoftwareversions/tests/main.nf.test
+++ b/modules/nf-core/custom/dumpsoftwareversions/tests/main.nf.test
@@ -1,0 +1,43 @@
+nextflow_process {
+
+    name "Test Process CUSTOM_DUMPSOFTWAREVERSIONS"
+    script "../main.nf"
+    process "CUSTOM_DUMPSOFTWAREVERSIONS"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "custom"
+    tag "dumpsoftwareversions"
+    tag "custom/dumpsoftwareversions"
+
+    test("Should run without failures") {
+        when {
+            process {
+                """
+                def tool1_version = '''
+                TOOL1:
+                    tool1: 0.11.9
+                '''.stripIndent()
+
+                def tool2_version = '''
+                TOOL2:
+                    tool2: 1.9
+                '''.stripIndent()
+
+                input[0] = Channel.of(tool1_version, tool2_version).collectFile()
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(
+                    process.out.versions,
+                    file(process.out.mqc_yml[0]).readLines()[0..10],
+                    file(process.out.yml[0]).readLines()[0..7]
+                    ).match()
+                }
+            )
+        }
+    }
+}

--- a/modules/nf-core/custom/dumpsoftwareversions/tests/main.nf.test.snap
+++ b/modules/nf-core/custom/dumpsoftwareversions/tests/main.nf.test.snap
@@ -1,0 +1,33 @@
+{
+    "Should run without failures": {
+        "content": [
+            [
+                "versions.yml:md5,76d454d92244589d32455833f7c1ba6d"
+            ],
+            [
+                "data: \"<style>\\n#nf-core-versions tbody:nth-child(even) {\\n    background-color: #f2f2f2;\\n\\",
+                "  }\\n</style>\\n<table class=\\\"table\\\" style=\\\"width:100%\\\" id=\\\"nf-core-versions\\\"\\",
+                "  >\\n    <thead>\\n        <tr>\\n            <th> Process Name </th>\\n            <th>\\",
+                "  \\ Software </th>\\n            <th> Version  </th>\\n        </tr>\\n    </thead>\\n\\",
+                "  \\n<tbody>\\n<tr>\\n    <td><samp>CUSTOM_DUMPSOFTWAREVERSIONS</samp></td>\\n    <td><samp>python</samp></td>\\n\\",
+                "  \\    <td><samp>3.11.7</samp></td>\\n</tr>\\n\\n<tr>\\n    <td><samp></samp></td>\\n \\",
+                "  \\   <td><samp>yaml</samp></td>\\n    <td><samp>5.4.1</samp></td>\\n</tr>\\n\\n</tbody>\\n\\",
+                "  <tbody>\\n<tr>\\n    <td><samp>TOOL1</samp></td>\\n    <td><samp>tool1</samp></td>\\n\\",
+                "  \\    <td><samp>0.11.9</samp></td>\\n</tr>\\n\\n</tbody>\\n<tbody>\\n<tr>\\n    <td><samp>TOOL2</samp></td>\\n\\",
+                "  \\    <td><samp>tool2</samp></td>\\n    <td><samp>1.9</samp></td>\\n</tr>\\n\\n</tbody>\\n\\",
+                "  <tbody>\\n<tr>\\n    <td><samp>Workflow</samp></td>\\n    <td><samp>Nextflow</samp></td>\\n\\"
+            ],
+            [
+                "CUSTOM_DUMPSOFTWAREVERSIONS:",
+                "  python: 3.11.7",
+                "  yaml: 5.4.1",
+                "TOOL1:",
+                "  tool1: 0.11.9",
+                "TOOL2:",
+                "  tool2: '1.9'",
+                "Workflow:"
+            ]
+        ],
+        "timestamp": "2024-01-09T23:01:18.710682"
+    }
+}

--- a/modules/nf-core/custom/dumpsoftwareversions/tests/tags.yml
+++ b/modules/nf-core/custom/dumpsoftwareversions/tests/tags.yml
@@ -1,0 +1,2 @@
+custom/dumpsoftwareversions:
+  - modules/nf-core/custom/dumpsoftwareversions/**

--- a/modules/nf-core/fastqc/environment.yml
+++ b/modules/nf-core/fastqc/environment.yml
@@ -1,0 +1,7 @@
+name: fastqc
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::fastqc=0.12.1

--- a/modules/nf-core/fastqc/main.nf
+++ b/modules/nf-core/fastqc/main.nf
@@ -2,10 +2,10 @@ process FASTQC {
     tag "$meta.id"
     label 'process_medium'
 
-    conda "bioconda::fastqc=0.11.9"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/fastqc:0.11.9--0' :
-        'biocontainers/fastqc:0.11.9--0' }"
+        'https://depot.galaxyproject.org/singularity/fastqc:0.12.1--hdfd78af_0' :
+        'biocontainers/fastqc:0.12.1--hdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)
@@ -37,7 +37,7 @@ process FASTQC {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
+        fastqc: \$( fastqc --version | sed '/FastQC v/!d; s/.*v//' )
     END_VERSIONS
     """
 
@@ -49,7 +49,7 @@ process FASTQC {
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":
-        fastqc: \$( fastqc --version | sed -e "s/FastQC v//g" )
+        fastqc: \$( fastqc --version | sed '/FastQC v/!d; s/.*v//' )
     END_VERSIONS
     """
 }

--- a/modules/nf-core/fastqc/meta.yml
+++ b/modules/nf-core/fastqc/meta.yml
@@ -50,3 +50,8 @@ authors:
   - "@grst"
   - "@ewels"
   - "@FelixKrueger"
+maintainers:
+  - "@drpatelh"
+  - "@grst"
+  - "@ewels"
+  - "@FelixKrueger"

--- a/modules/nf-core/fastqc/tests/main.nf.test
+++ b/modules/nf-core/fastqc/tests/main.nf.test
@@ -1,32 +1,220 @@
 nextflow_process {
 
     name "Test Process FASTQC"
-    script "modules/nf-core/fastqc/main.nf"
+    script "../main.nf"
     process "FASTQC"
+
+    tag "modules"
+    tag "modules_nfcore"
     tag "fastqc"
 
-    test("Single-Read") {
+    test("sarscov2 single-end [fastq]") {
 
         when {
             process {
                 """
                 input[0] = [
-                    [ id: 'test', single_end:true ],
-                    [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
-                    ]
+                            [ id: 'test', single_end:true ],
+                            [
+                                file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                            ]
                 ]
                 """
             }
         }
 
         then {
-            assert process.success
-            assert process.out.html.get(0).get(1) ==~ ".*/test_fastqc.html"
-            assert path(process.out.html.get(0).get(1)).getText().contains("<tr><td>File type</td><td>Conventional base calls</td></tr>")
-            assert process.out.zip.get(0).get(1) ==~ ".*/test_fastqc.zip"
+            assertAll (
+            { assert process.success },
+
+            // NOTE The report contains the date inside it, which means that the md5sum is stable per day, but not longer than that. So you can't md5sum it.
+            // looks like this: <div id="header_filename">Mon 2 Oct 2023<br/>test.gz</div>
+            // https://github.com/nf-core/modules/pull/3903#issuecomment-1743620039
+
+            { assert process.out.html[0][1] ==~ ".*/test_fastqc.html" },
+            { assert process.out.zip[0][1] ==~ ".*/test_fastqc.zip" },
+            { assert path(process.out.html[0][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+
+            { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+
+    test("sarscov2 paired-end [fastq]") {
+
+        when {
+            process {
+            """
+            input[0] = [
+                        [id: 'test', single_end: false], // meta map
+                        [
+                            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        ]
+            ]
+            """
+            }
         }
 
+        then {
+            assertAll (
+            { assert process.success },
+
+            { assert process.out.html[0][1][0] ==~ ".*/test_1_fastqc.html" },
+            { assert process.out.html[0][1][1] ==~ ".*/test_2_fastqc.html" },
+            { assert process.out.zip[0][1][0] ==~ ".*/test_1_fastqc.zip" },
+            { assert process.out.zip[0][1][1] ==~ ".*/test_2_fastqc.zip" },
+            { assert path(process.out.html[0][1][0]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+            { assert path(process.out.html[0][1][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+
+            { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+
+    test("sarscov2 interleaved [fastq]") {
+
+        when {
+            process {
+            """
+            input[0] = [
+                        [id: 'test', single_end: false], // meta map
+                        file(params.test_data['sarscov2']['illumina']['test_interleaved_fastq_gz'], checkIfExists: true)
+            ]
+            """
+            }
+        }
+
+        then {
+            assertAll (
+            { assert process.success },
+
+            { assert process.out.html[0][1] ==~ ".*/test_fastqc.html" },
+            { assert process.out.zip[0][1] ==~ ".*/test_fastqc.zip" },
+            { assert path(process.out.html[0][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+
+            { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+
+    test("sarscov2 paired-end [bam]") {
+
+        when {
+            process {
+            """
+            input[0] = [
+                        [id: 'test', single_end: false], // meta map
+                        file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true)
+            ]
+            """
+            }
+        }
+
+        then {
+            assertAll (
+            { assert process.success },
+
+            { assert process.out.html[0][1] ==~ ".*/test_fastqc.html" },
+            { assert process.out.zip[0][1] ==~ ".*/test_fastqc.zip" },
+            { assert path(process.out.html[0][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+
+            { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+
+    test("sarscov2 multiple [fastq]") {
+
+        when {
+            process {
+            """
+            input[0] = [
+                        [id: 'test', single_end: false], // meta map
+                        [
+                            file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                            file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true),
+                            file(params.test_data['sarscov2']['illumina']['test2_1_fastq_gz'], checkIfExists: true),
+                            file(params.test_data['sarscov2']['illumina']['test2_2_fastq_gz'], checkIfExists: true)
+                        ]
+            ]
+            """
+            }
+        }
+
+        then {
+            assertAll (
+            { assert process.success },
+
+            { assert process.out.html[0][1][0] ==~ ".*/test_1_fastqc.html" },
+            { assert process.out.html[0][1][1] ==~ ".*/test_2_fastqc.html" },
+            { assert process.out.html[0][1][2] ==~ ".*/test_3_fastqc.html" },
+            { assert process.out.html[0][1][3] ==~ ".*/test_4_fastqc.html" },
+            { assert process.out.zip[0][1][0] ==~ ".*/test_1_fastqc.zip" },
+            { assert process.out.zip[0][1][1] ==~ ".*/test_2_fastqc.zip" },
+            { assert process.out.zip[0][1][2] ==~ ".*/test_3_fastqc.zip" },
+            { assert process.out.zip[0][1][3] ==~ ".*/test_4_fastqc.zip" },
+            { assert path(process.out.html[0][1][0]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+            { assert path(process.out.html[0][1][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+            { assert path(process.out.html[0][1][2]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+            { assert path(process.out.html[0][1][3]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+
+            { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+
+    test("sarscov2 custom_prefix") {
+
+        when {
+            process {
+            """
+            input[0] = [
+                        [ id:'mysample', single_end:true ], // meta map
+                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+            ]
+            """
+            }
+        }
+
+        then {
+            assertAll (
+            { assert process.success },
+
+            { assert process.out.html[0][1] ==~ ".*/mysample_fastqc.html" },
+            { assert process.out.zip[0][1] ==~ ".*/mysample_fastqc.zip" },
+            { assert path(process.out.html[0][1]).text.contains("<tr><td>File type</td><td>Conventional base calls</td></tr>") },
+
+            { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+
+    test("sarscov2 single-end [fastq] - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                            [ id: 'test', single_end:true ],
+                            [
+                                file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                            ]
+                ]
+                """
+            }
+        }
+
+        then {
+            assertAll (
+            { assert process.success },
+            { assert snapshot(process.out.html.collect { file(it[1]).getName() } +
+                                process.out.zip.collect { file(it[1]).getName() } +
+                                process.out.versions ).match() }
+            )
+        }
     }
 
 }

--- a/modules/nf-core/fastqc/tests/main.nf.test.snap
+++ b/modules/nf-core/fastqc/tests/main.nf.test.snap
@@ -1,0 +1,20 @@
+{
+    "sarscov2 single-end [fastq] - stub": {
+        "content": [
+            [
+                "test.html",
+                "test.zip",
+                "versions.yml:md5,e1cc25ca8af856014824abd842e93978"
+            ]
+        ],
+        "timestamp": "2023-12-29T02:48:05.126117287"
+    },
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,e1cc25ca8af856014824abd842e93978"
+            ]
+        ],
+        "timestamp": "2023-12-29T02:46:49.507942667"
+    }
+}

--- a/modules/nf-core/fastqc/tests/tags.yml
+++ b/modules/nf-core/fastqc/tests/tags.yml
@@ -1,0 +1,2 @@
+fastqc:
+  - modules/nf-core/fastqc/**

--- a/modules/nf-core/filtlong/environment.yml
+++ b/modules/nf-core/filtlong/environment.yml
@@ -1,0 +1,7 @@
+name: filtlong
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::filtlong=0.2.1

--- a/modules/nf-core/filtlong/main.nf
+++ b/modules/nf-core/filtlong/main.nf
@@ -2,7 +2,7 @@ process FILTLONG {
     tag "$meta.id"
     label 'process_low'
 
-    conda "bioconda::filtlong=0.2.1"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/filtlong:0.2.1--h9a82719_0' :
         'biocontainers/filtlong:0.2.1--h9a82719_0' }"
@@ -28,7 +28,7 @@ process FILTLONG {
         $short_reads \\
         $args \\
         $longreads \\
-        2> ${prefix}.log \\
+        2> >(tee ${prefix}.log >&2) \\
         | gzip -n > ${prefix}.fastq.gz
 
     cat <<-END_VERSIONS > versions.yml

--- a/modules/nf-core/filtlong/meta.yml
+++ b/modules/nf-core/filtlong/meta.yml
@@ -11,11 +11,8 @@ tools:
   - filtlong:
       description: Filtlong is a tool for filtering long reads. It can take a set of long reads and produce a smaller, better subset. It uses both read length (longer is better) and read identity (higher is better) when choosing which reads pass the filter.
       homepage: https://anaconda.org/bioconda/filtlong
-
       tool_dev_url: https://github.com/rrwick/Filtlong
-
       licence: ["GPL v3"]
-
 input:
   - meta:
       type: map
@@ -30,7 +27,6 @@ input:
       type: file
       description: fastq file
       pattern: "*.{fq,fastq,fq.gz,fastq.gz}"
-
 output:
   - meta:
       type: map
@@ -49,7 +45,9 @@ output:
       type: file
       description: Standard error logging file containing summary statistics
       pattern: "*.log"
-
 authors:
+  - "@d4straub"
+  - "@sofstam"
+maintainers:
   - "@d4straub"
   - "@sofstam"

--- a/modules/nf-core/filtlong/tests/main.nf.test
+++ b/modules/nf-core/filtlong/tests/main.nf.test
@@ -1,0 +1,99 @@
+nextflow_process {
+
+    name "Test Process FILTLONG"
+    script "../main.nf"
+    process "FILTLONG"
+    config "./nextflow.config"
+    tag "filtlong"
+    tag "modules"
+    tag "modules_nfcore"
+
+    test("sarscov2 nanopore [fastq]") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:false ], // meta map
+                            [],
+                            [ file(params.test_data['sarscov2']['nanopore']['test_fastq_gz'], checkIfExists: true) ]
+                           ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
+                { assert snapshot(process.out.reads).match("nanopore") },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+
+    test("sarscov2 nanopore [fastq] + Illumina single-end [fastq]") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:true ], // meta map
+                            [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true) ],
+                            [ file(params.test_data['sarscov2']['nanopore']['test_fastq_gz'], checkIfExists: true) ]
+                           ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
+                { assert snapshot(process.out.reads).match("nanopore_illumina_se") },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+
+    test("sarscov2 nanopore [fastq] + Illumina paired-end [fastq]") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = [
+                            [ id:'test', single_end:false ], // meta map
+                            [ file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                              file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true) ],
+                            [ file(params.test_data['sarscov2']['nanopore']['test_fastq_gz'], checkIfExists: true) ]
+                           ]
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.log.get(0).get(1)).readLines().contains("Scoring long reads")},
+                { assert snapshot(process.out.reads).match("nanopore_illumina_pe") },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+
+}

--- a/modules/nf-core/filtlong/tests/main.nf.test.snap
+++ b/modules/nf-core/filtlong/tests/main.nf.test.snap
@@ -1,0 +1,52 @@
+{
+    "nanopore": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                ]
+            ]
+        ],
+        "timestamp": "2023-12-11T14:23:36.351509"
+    },
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,af5988f30157282acdb0ac50ebb4c8cc"
+            ]
+        ],
+        "timestamp": "2023-12-11T14:23:36.372189"
+    },
+    "nanopore_illumina_pe": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                ]
+            ]
+        ],
+        "timestamp": "2023-12-11T14:24:05.202047"
+    },
+    "nanopore_illumina_se": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test_lr.fastq.gz:md5,7567d853ada6ac142332619d0b541d76"
+                ]
+            ]
+        ],
+        "timestamp": "2023-12-11T14:23:50.607338"
+    }
+}

--- a/modules/nf-core/filtlong/tests/nextflow.config
+++ b/modules/nf-core/filtlong/tests/nextflow.config
@@ -1,0 +1,8 @@
+process {
+
+    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
+
+    ext.args = "--min_length 10"
+    ext.prefix = "test_lr"
+
+}

--- a/modules/nf-core/filtlong/tests/tags.yml
+++ b/modules/nf-core/filtlong/tests/tags.yml
@@ -1,0 +1,2 @@
+filtlong:
+  - modules/nf-core/filtlong/**

--- a/modules/nf-core/multiqc/environment.yml
+++ b/modules/nf-core/multiqc/environment.yml
@@ -1,0 +1,7 @@
+name: multiqc
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::multiqc=1.19

--- a/modules/nf-core/multiqc/main.nf
+++ b/modules/nf-core/multiqc/main.nf
@@ -1,10 +1,10 @@
 process MULTIQC {
     label 'process_single'
 
-    conda "bioconda::multiqc=1.15"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/multiqc:1.15--pyhdfd78af_0' :
-        'biocontainers/multiqc:1.15--pyhdfd78af_0' }"
+        'https://depot.galaxyproject.org/singularity/multiqc:1.19--pyhdfd78af_0' :
+        'biocontainers/multiqc:1.19--pyhdfd78af_0' }"
 
     input:
     path  multiqc_files, stageAs: "?/*"
@@ -25,12 +25,14 @@ process MULTIQC {
     def args = task.ext.args ?: ''
     def config = multiqc_config ? "--config $multiqc_config" : ''
     def extra_config = extra_multiqc_config ? "--config $extra_multiqc_config" : ''
+    def logo = multiqc_logo ? /--cl-config 'custom_logo: "${multiqc_logo}"'/ : ''
     """
     multiqc \\
         --force \\
         $args \\
         $config \\
         $extra_config \\
+        $logo \\
         .
 
     cat <<-END_VERSIONS > versions.yml
@@ -41,7 +43,7 @@ process MULTIQC {
 
     stub:
     """
-    touch multiqc_data
+    mkdir multiqc_data
     touch multiqc_plots
     touch multiqc_report.html
 

--- a/modules/nf-core/multiqc/meta.yml
+++ b/modules/nf-core/multiqc/meta.yml
@@ -1,5 +1,4 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
-name: MultiQC
+name: multiqc
 description: Aggregate results from bioinformatics analyses across many samples into a single report
 keywords:
   - QC
@@ -13,7 +12,6 @@ tools:
       homepage: https://multiqc.info/
       documentation: https://multiqc.info/docs/
       licence: ["GPL-3.0-or-later"]
-
 input:
   - multiqc_files:
       type: file
@@ -31,7 +29,6 @@ input:
       type: file
       description: Optional logo file for MultiQC
       pattern: "*.{png}"
-
 output:
   - report:
       type: file
@@ -50,6 +47,11 @@ output:
       description: File containing software versions
       pattern: "versions.yml"
 authors:
+  - "@abhi18av"
+  - "@bunop"
+  - "@drpatelh"
+  - "@jfy133"
+maintainers:
   - "@abhi18av"
   - "@bunop"
   - "@drpatelh"

--- a/modules/nf-core/multiqc/tests/main.nf.test
+++ b/modules/nf-core/multiqc/tests/main.nf.test
@@ -1,0 +1,83 @@
+nextflow_process {
+
+    name "Test Process MULTIQC"
+    script "../main.nf"
+    process "MULTIQC"
+    tag "modules"
+    tag "modules_nfcore"
+    tag "multiqc"
+
+    test("sarscov2 single-end [fastqc]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz_fastqc_zip'], checkIfExists: true)])
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
+                { assert process.out.data[0] ==~ ".*/multiqc_data" },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+
+    }
+
+    test("sarscov2 single-end [fastqc] [config]") {
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz_fastqc_zip'], checkIfExists: true)])
+                input[1] = Channel.of(file("https://github.com/nf-core/tools/raw/dev/nf_core/pipeline-template/assets/multiqc_config.yml", checkIfExists: true))
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert process.out.report[0] ==~ ".*/multiqc_report.html" },
+                { assert process.out.data[0] ==~ ".*/multiqc_data" },
+                { assert snapshot(process.out.versions).match("versions") }
+            )
+        }
+    }
+
+    test("sarscov2 single-end [fastqc] - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = Channel.of([file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz_fastqc_zip'], checkIfExists: true)])
+                input[1] = []
+                input[2] = []
+                input[3] = []
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out.report.collect { file(it).getName() } +
+                                process.out.data.collect { file(it).getName() } +
+                                process.out.plots.collect { file(it).getName() } +
+                                process.out.versions ).match() }
+            )
+        }
+
+    }
+}

--- a/modules/nf-core/multiqc/tests/main.nf.test.snap
+++ b/modules/nf-core/multiqc/tests/main.nf.test.snap
@@ -1,0 +1,21 @@
+{
+    "versions": {
+        "content": [
+            [
+                "versions.yml:md5,14e9a2661241abd828f4f06a7b5c222d"
+            ]
+        ],
+        "timestamp": "2024-01-09T23:02:49.911994"
+    },
+    "sarscov2 single-end [fastqc] - stub": {
+        "content": [
+            [
+                "multiqc_report.html",
+                "multiqc_data",
+                "multiqc_plots",
+                "versions.yml:md5,14e9a2661241abd828f4f06a7b5c222d"
+            ]
+        ],
+        "timestamp": "2024-01-09T23:03:14.524346"
+    }
+}

--- a/modules/nf-core/multiqc/tests/tags.yml
+++ b/modules/nf-core/multiqc/tests/tags.yml
@@ -1,0 +1,2 @@
+multiqc:
+  - modules/nf-core/multiqc/**


### PR DESCRIPTION
This PR updates the following modules:

- multiqc
- fastqc
- adapterremoval
- dumpsoftwareversions
- filtlong

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
