### PR TITLE
Fix the multiple fastq outputs in LONGREAD_HOSTREMOVAL

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -380,7 +380,7 @@ process {
             [
                 path: { "${params.outdir}/samtools/fastq" },
                 mode: params.publish_dir_mode,
-                pattern: '*.fastq.gz',
+                pattern: '*.unmapped_other.fastq.gz',
                 enabled: params.save_hostremoval_unmapped
             ],
             [

--- a/subworkflows/local/longread_hostremoval.nf
+++ b/subworkflows/local/longread_hostremoval.nf
@@ -54,7 +54,7 @@ workflow LONGREAD_HOSTREMOVAL {
 
     emit:
     stats    = SAMTOOLS_STATS.out.stats     //channel: [val(meta), [reads  ] ]
-    reads    = SAMTOOLS_FASTQ.out.fastq.mix( SAMTOOLS_FASTQ.out.other)   // channel: [ val(meta), [ reads ] ]
+    reads    = SAMTOOLS_FASTQ.out.other   // channel: [ val(meta), [ reads ] ]
     versions = ch_versions                 // channel: [ versions.yml ]
     mqc      = ch_multiqc_files
 }


### PR DESCRIPTION
<!--
# nf-core/taxprofiler pull request

Many thanks for contributing to nf-core/taxprofiler!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
-->

Close the issue #429 


## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
