### PR TITLE
Update kaiju2table module

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,11 +18,11 @@
                 "python.linting.flake8Path": "/opt/conda/bin/flake8",
                 "python.linting.pycodestylePath": "/opt/conda/bin/pycodestyle",
                 "python.linting.pydocstylePath": "/opt/conda/bin/pydocstyle",
-                "python.linting.pylintPath": "/opt/conda/bin/pylint"
+                "python.linting.pylintPath": "/opt/conda/bin/pylint",
             },
 
             // Add the IDs of extensions you want installed when the container is created.
-            "extensions": ["ms-python.python", "ms-python.vscode-pylance", "nf-core.nf-core-extensionpack"]
-        }
-    }
+            "extensions": ["ms-python.python", "ms-python.vscode-pylance", "nf-core.nf-core-extensionpack"],
+        },
+    },
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,11 +18,11 @@
                 "python.linting.flake8Path": "/opt/conda/bin/flake8",
                 "python.linting.pycodestylePath": "/opt/conda/bin/pycodestyle",
                 "python.linting.pydocstylePath": "/opt/conda/bin/pydocstyle",
-                "python.linting.pylintPath": "/opt/conda/bin/pylint",
+                "python.linting.pylintPath": "/opt/conda/bin/pylint"
             },
 
             // Add the IDs of extensions you want installed when the container is created.
-            "extensions": ["ms-python.python", "ms-python.vscode-pylance", "nf-core.nf-core-extensionpack"],
-        },
-    },
+            "extensions": ["ms-python.python", "ms-python.vscode-pylance", "nf-core.nf-core-extensionpack"]
+        }
+    }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,11 +18,11 @@
                 "python.linting.flake8Path": "/opt/conda/bin/flake8",
                 "python.linting.pycodestylePath": "/opt/conda/bin/pycodestyle",
                 "python.linting.pydocstylePath": "/opt/conda/bin/pydocstyle",
-                "python.linting.pylintPath": "/opt/conda/bin/pylint"
+                "python.linting.pylintPath": "/opt/conda/bin/pylint",
             },
 
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": ["ms-python.python", "ms-python.vscode-pylance", "nf-core.nf-core-extensionpack"]
-        }
-    }
+        },
+    },
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,11 +18,11 @@
                 "python.linting.flake8Path": "/opt/conda/bin/flake8",
                 "python.linting.pycodestylePath": "/opt/conda/bin/pycodestyle",
                 "python.linting.pydocstylePath": "/opt/conda/bin/pydocstyle",
-                "python.linting.pylintPath": "/opt/conda/bin/pylint",
+                "python.linting.pylintPath": "/opt/conda/bin/pylint"
             },
 
             // Add the IDs of extensions you want installed when the container is created.
             "extensions": ["ms-python.python", "ms-python.vscode-pylance", "nf-core.nf-core-extensionpack"]
-        },
-    },
+        }
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Fixed`
 
+[#431](https://github.com/nf-core/modules/pull/4781#event-11555493525) Updated kaiju2table module to report taxon names (fix by @Joon-Klaps)
+
 ### `Dependencies`
+
+| Tool          | Previous version | New version |
+| ------------- | ---------------- | ----------- |
+| kaiju         | 1.8.2            | 1.10.0      |
+
+
 
 ### `Deprecated`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#431](https://github.com/nf-core/modules/pull/4781#event-11555493525) Updated kaiju2table module to report taxon names (fix by @Joon-Klaps)
 - [#430](https://github.com/nf-core/taxprofiler/pull/430) Fix the fastq output in the module LONGREAD_HOSTREMOVAL. (fix by @LilyAnderssonLee)
 
-
 ### `Dependencies`
 
 | Tool  | Previous version | New version |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Dependencies`
 
-| Tool          | Previous version | New version |
-| ------------- | ---------------- | ----------- |
-| kaiju         | 1.8.2            | 1.10.0      |
-
-
+| Tool  | Previous version | New version |
+| ----- | ---------------- | ----------- |
+| kaiju | 1.8.2            | 1.10.0      |
 
 ### `Deprecated`
 

--- a/modules.json
+++ b/modules.json
@@ -113,7 +113,7 @@
                     },
                     "kaiju/kaiju2table": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "3db50674956b1fb3741a44eb917458d788a50197",
                         "installed_by": ["modules"]
                     },
                     "kmcp/profile": {

--- a/modules.json
+++ b/modules.json
@@ -103,12 +103,12 @@
                     },
                     "kaiju/kaiju": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "3db50674956b1fb3741a44eb917458d788a50197",
                         "installed_by": ["modules"]
                     },
                     "kaiju/kaiju2krona": {
                         "branch": "master",
-                        "git_sha": "911696ea0b62df80e900ef244d7867d177971f73",
+                        "git_sha": "3db50674956b1fb3741a44eb917458d788a50197",
                         "installed_by": ["modules"]
                     },
                     "kaiju/kaiju2table": {

--- a/modules/nf-core/kaiju/kaiju/environment.yml
+++ b/modules/nf-core/kaiju/kaiju/environment.yml
@@ -1,0 +1,7 @@
+name: kaiju_kaiju
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::kaiju=1.10.0

--- a/modules/nf-core/kaiju/kaiju/main.nf
+++ b/modules/nf-core/kaiju/kaiju/main.nf
@@ -2,10 +2,10 @@ process KAIJU_KAIJU {
     tag "$meta.id"
     label 'process_high'
 
-    conda "bioconda::kaiju=1.8.2"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/kaiju:1.8.2--h5b5514e_1':
-        'biocontainers/kaiju:1.8.2--h5b5514e_1' }"
+        'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0':
+        'biocontainers/kaiju:1.10.0--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(reads)
@@ -38,4 +38,18 @@ process KAIJU_KAIJU {
         kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
     END_VERSIONS
     """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def input = meta.single_end ? "-i ${reads}" : "-i ${reads[0]} -j ${reads[1]}"
+    """
+    touch ${prefix}.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
+    END_VERSIONS
+    """
+
 }

--- a/modules/nf-core/kaiju/kaiju/meta.yml
+++ b/modules/nf-core/kaiju/kaiju/meta.yml
@@ -13,7 +13,6 @@ tools:
       tool_dev_url: https://github.com/bioinformatics-centre/kaiju
       doi: "10.1038/ncomms11257"
       licence: ["GNU GPL v3"]
-
 input:
   - meta:
       type: map
@@ -27,11 +26,10 @@ input:
         respectively.
       pattern: "*.{fastq,fq,fasta,fa,fsa,fas,fna,fastq.gz,fq.gz,fasta.gz,fa.gz,fsa.gz,fas.gz,fna.gz}"
   - db:
-      type: files
+      type: directory
       description: |
         List containing the database and nodes files for Kaiju
         e.g. [ 'database.fmi', 'nodes.dmp' ]
-
 output:
   - meta:
       type: map
@@ -46,8 +44,11 @@ output:
       type: file
       description: Results with taxonomic classification of each read
       pattern: "*.tsv"
-
 authors:
+  - "@talnor"
+  - "@sofstam"
+  - "@jfy133"
+maintainers:
   - "@talnor"
   - "@sofstam"
   - "@jfy133"

--- a/modules/nf-core/kaiju/kaiju/tests/main.nf.test
+++ b/modules/nf-core/kaiju/kaiju/tests/main.nf.test
@@ -1,0 +1,117 @@
+nextflow_process {
+
+    name "Test Process KAIJU_KAIJU"
+    script "../main.nf"
+    process "KAIJU_KAIJU"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "kaiju"
+    tag "kaiju/kaiju"
+    tag "untar"
+
+    test("sarscov2 - fastq - single-end") {
+
+        setup {
+            run ("UNTAR"){
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] =  [
+                        [ id:'test', single_end:true ], // meta map
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                        ]
+                input[1] = UNTAR.out.untar.map{ it[1] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.results[0][1]).getText().contains("C\tERR5069949.2257580\t2697049") }
+            )
+        }
+
+    }
+
+    test("sarscov2 - fastq - paired-end") {
+
+        setup {
+            run ("UNTAR"){
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
+                ]
+                input[1] = UNTAR.out.untar.map{ it[1] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert path(process.out.results[0][1]).getText().contains("C\tERR5069949.2257580\t2697049") }
+            )
+        }
+    }
+
+    test("sarscov2 - fastq - stub") {
+
+        options '-stub'
+
+        setup {
+            run ("UNTAR"){
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
+                ]
+                input[1] = UNTAR.out.untar.map{ it[1] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.results[0][1]).name).match() }
+            )
+        }
+    }
+
+}

--- a/modules/nf-core/kaiju/kaiju/tests/main.nf.test.snap
+++ b/modules/nf-core/kaiju/kaiju/tests/main.nf.test.snap
@@ -1,0 +1,8 @@
+{
+    "sarscov2 - fastq - stub": {
+        "content": [
+            "test.tsv"
+        ],
+        "timestamp": "2024-01-20T14:44:57.116024519"
+    }
+}

--- a/modules/nf-core/kaiju/kaiju/tests/tags.yml
+++ b/modules/nf-core/kaiju/kaiju/tests/tags.yml
@@ -1,0 +1,2 @@
+kaiju/kaiju:
+  - "modules/nf-core/kaiju/kaiju/**"

--- a/modules/nf-core/kaiju/kaiju2krona/environment.yml
+++ b/modules/nf-core/kaiju/kaiju2krona/environment.yml
@@ -1,0 +1,7 @@
+name: kaiju_kaiju2krona
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::kaiju=1.10.0

--- a/modules/nf-core/kaiju/kaiju2krona/main.nf
+++ b/modules/nf-core/kaiju/kaiju2krona/main.nf
@@ -2,10 +2,10 @@ process KAIJU_KAIJU2KRONA {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::kaiju=1.8.2"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/kaiju:1.8.2--h5b5514e_1':
-        'biocontainers/kaiju:1.8.2--h5b5514e_1' }"
+        'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0':
+        'biocontainers/kaiju:1.10.0--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(tsv)
@@ -36,4 +36,17 @@ process KAIJU_KAIJU2KRONA {
         kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
     END_VERSIONS
     """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.txt
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
+    END_VERSIONS
+    """
 }
+

--- a/modules/nf-core/kaiju/kaiju2krona/meta.yml
+++ b/modules/nf-core/kaiju/kaiju2krona/meta.yml
@@ -13,7 +13,6 @@ tools:
       tool_dev_url: https://github.com/bioinformatics-centre/kaiju
       doi: "10.1038/ncomms11257"
       licence: ["GNU GPL v3"]
-
 input:
   - meta:
       type: map
@@ -24,7 +23,6 @@ input:
       type: file
       description: Kaiju tab-separated output file
       pattern: "*.{tsv,txt}"
-
 output:
   - meta:
       type: map
@@ -39,6 +37,7 @@ output:
       type: file
       description: Krona text-based input file converted from Kaiju report
       pattern: "*.{txt,krona}"
-
 authors:
+  - "@MillironX"
+maintainers:
   - "@MillironX"

--- a/modules/nf-core/kaiju/kaiju2krona/tests/main.nf.test
+++ b/modules/nf-core/kaiju/kaiju2krona/tests/main.nf.test
@@ -1,0 +1,105 @@
+nextflow_process {
+
+    name "Test Process KAIJU_KAIJU2KRONA"
+    script "../main.nf"
+    process "KAIJU_KAIJU2KRONA"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "kaiju"
+    tag "kaiju/kaiju2krona"
+    tag "kaiju/kaiju"
+    tag "untar"
+
+    test("sarscov2 - fastq - single-end") {
+
+
+        setup {
+            run ("UNTAR"){
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
+                    """
+                }
+            }
+
+            run("KAIJU_KAIJU") {
+                script "../../kaiju/main.nf"
+                process {
+                    """
+                    input[0] =  [
+                            [ id:'test', single_end:true ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                            ]
+                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    """
+                }
+            }
+        }
+
+            when {
+                process {
+                    """
+                    input[0] = KAIJU_KAIJU.out.results
+                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    """
+                }
+            }
+
+            then {
+                assertAll(
+                    { assert process.success },
+                    { assert snapshot(process.out).match() }
+                )
+            }
+
+    }
+
+    test("sarscov2 - fastq - stub") {
+
+        options "-stub"
+
+        setup {
+            run ("UNTAR"){
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
+                    """
+                }
+            }
+
+            run("KAIJU_KAIJU") {
+                script "../../kaiju/main.nf"
+                process {
+                    """
+                    input[0] =  [
+                            [ id:'test', single_end:true ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                            ]
+                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = KAIJU_KAIJU.out.results
+                input[1] = UNTAR.out.untar.map{ it[1] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.txt[0][1]).name).match() }
+            )
+        }
+
+    }
+
+}

--- a/modules/nf-core/kaiju/kaiju2krona/tests/main.nf.test.snap
+++ b/modules/nf-core/kaiju/kaiju2krona/tests/main.nf.test.snap
@@ -1,0 +1,39 @@
+{
+    "sarscov2 - fastq - stub": {
+        "content": [
+            "test.txt"
+        ],
+        "timestamp": "2024-01-20T15:06:32.789121011"
+    },
+    "sarscov2 - fastq - single-end": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.txt:md5,68b2309d37767e444193fa6cea7c0494"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,f75aa349971d581981d3a0399450b395"
+                ],
+                "txt": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.txt:md5,68b2309d37767e444193fa6cea7c0494"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,f75aa349971d581981d3a0399450b395"
+                ]
+            }
+        ],
+        "timestamp": "2024-01-20T15:06:08.840865115"
+    }
+}

--- a/modules/nf-core/kaiju/kaiju2krona/tests/tags.yml
+++ b/modules/nf-core/kaiju/kaiju2krona/tests/tags.yml
@@ -1,0 +1,2 @@
+kaiju/kaiju2krona:
+  - "modules/nf-core/kaiju/kaiju2krona/**"

--- a/modules/nf-core/kaiju/kaiju2table/environment.yml
+++ b/modules/nf-core/kaiju/kaiju2table/environment.yml
@@ -1,0 +1,7 @@
+name: kaiju_kaiju2table
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::kaiju=1.10.0

--- a/modules/nf-core/kaiju/kaiju2table/main.nf
+++ b/modules/nf-core/kaiju/kaiju2table/main.nf
@@ -2,13 +2,13 @@ process KAIJU_KAIJU2TABLE {
     tag "$meta.id"
     label 'process_single'
 
-    conda "bioconda::kaiju=1.8.2"
+    conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/kaiju:1.8.2--h5b5514e_1':
-        'biocontainers/kaiju:1.8.2--h2e03b76_0' }"
+        'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0':
+        'biocontainers/kaiju:1.10.0--h43eeafb_0' }"
 
     input:
-    tuple val(meta), path(results)
+    tuple val(meta), path(input)
     path db
     val taxon_rank
 
@@ -24,13 +24,25 @@ process KAIJU_KAIJU2TABLE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     dbnodes=`find -L ${db} -name "*nodes.dmp"`
-    dbname=`find -L ${db} -name "*.fmi" -not -name "._*"`
+    dbnames=`find -L ${db} -name "*names.dmp"`
     kaiju2table   $args \\
         -t \$dbnodes \\
-        -n \$dbname \\
+        -n \$dbnames \\
         -r ${taxon_rank} \\
         -o ${prefix}.txt \\
-        ${results}
+        ${input}
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
+    END_VERSIONS
+    """
+
+    stub:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    """
+    touch ${prefix}.txt
 
     cat <<-END_VERSIONS > versions.yml
     "${task.process}":

--- a/modules/nf-core/kaiju/kaiju2table/meta.yml
+++ b/modules/nf-core/kaiju/kaiju2table/meta.yml
@@ -3,6 +3,7 @@ description: write your description here
 keywords:
   - classify
   - metagenomics
+  - taxonomic profiling
 tools:
   - kaiju:
       description: Fast and sensitive taxonomic classification for metagenomics
@@ -11,7 +12,6 @@ tools:
       tool_dev_url: https://github.com/bioinformatics-centre/kaiju
       doi: "10.1038/ncomms11257"
       licence: ["GNU GPL v3"]
-
 input:
   - meta:
       type: map
@@ -27,7 +27,6 @@ input:
       description: |
         Taxonomic rank to display in report
         pattern: "phylum|class|order|family|genus|species"
-
 output:
   - meta:
       type: map
@@ -43,8 +42,11 @@ output:
       description: |
         Summary table for a given taxonomic rank
       pattern: "*.{tsv}"
-
 authors:
+  - "@sofstam"
+  - "@talnor"
+  - "@jfy133"
+maintainers:
   - "@sofstam"
   - "@talnor"
   - "@jfy133"

--- a/modules/nf-core/kaiju/kaiju2table/tests/main.nf.test
+++ b/modules/nf-core/kaiju/kaiju2table/tests/main.nf.test
@@ -1,0 +1,106 @@
+nextflow_process {
+
+    name "Test Process KAIJU_KAIJU2TABLE"
+    script "../main.nf"
+    process "KAIJU_KAIJU2TABLE"
+
+    tag "modules"
+    tag "modules_nfcore"
+    tag "kaiju"
+    tag "kaiju/kaiju2table"
+    tag "kaiju/kaiju"
+    tag "untar"
+
+    test("sarscov2 - fastq - single-end") {
+
+
+        setup {
+            run ("UNTAR"){
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
+                    """
+                }
+            }
+
+            run("KAIJU_KAIJU") {
+                script "../../kaiju/main.nf"
+                process {
+                    """
+                    input[0] =  [
+                            [ id:'test', single_end:true ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                            ]
+                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    """
+                }
+            }
+        }
+
+            when {
+                process {
+                    """
+                    input[0] = KAIJU_KAIJU.out.results
+                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    input[2] = 'species'
+                    """
+                }
+            }
+
+            then {
+                assertAll(
+                    { assert process.success },
+                    { assert snapshot(process.out).match() }
+                )
+            }
+
+    }
+
+    test("sarscov2 - fastq - stub") {
+
+        options "-stub"
+
+        setup {
+            run ("UNTAR"){
+                script "../../../untar/main.nf"
+                process {
+                    """
+                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
+                    """
+                }
+            }
+
+            run("KAIJU_KAIJU") {
+                script "../../kaiju/main.nf"
+                process {
+                    """
+                    input[0] =  [
+                            [ id:'test', single_end:true ], // meta map
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                            ]
+                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = KAIJU_KAIJU.out.results
+                input[1] = UNTAR.out.untar.map{ it[1] }
+                input[2] = 'species'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(file(process.out.summary[0][1]).name).match() }
+            )
+        }
+
+    }
+}

--- a/modules/nf-core/kaiju/kaiju2table/tests/main.nf.test.snap
+++ b/modules/nf-core/kaiju/kaiju2table/tests/main.nf.test.snap
@@ -1,0 +1,39 @@
+{
+    "sarscov2 - fastq - stub": {
+        "content": [
+            "test.txt"
+        ],
+        "timestamp": "2024-01-20T16:10:49.521322767"
+    },
+    "sarscov2 - fastq - single-end": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.txt:md5,0d9f8fd36fcf2888296ae12632c5f0a8"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,2b2b98cb635a611e5eb964e5a77f6248"
+                ],
+                "summary": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.txt:md5,0d9f8fd36fcf2888296ae12632c5f0a8"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,2b2b98cb635a611e5eb964e5a77f6248"
+                ]
+            }
+        ],
+        "timestamp": "2024-01-20T16:08:47.644443775"
+    }
+}

--- a/modules/nf-core/kaiju/kaiju2table/tests/tags.yml
+++ b/modules/nf-core/kaiju/kaiju2table/tests/tags.yml
@@ -1,0 +1,2 @@
+kaiju/kaiju2table:
+  - "modules/nf-core/kaiju/kaiju2table/**"


### PR DESCRIPTION
This PR updates the kaiju2table module in taxprofiler.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
