### PR TITLE
Include a pre-built kaiju indexes in tutorial.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#440](https://github.com/nf-core/taxprofiler/pull/440) Include pre-built kaiju databases in tutorial.md (added by @Joon-Klaps)
+
 ### `Fixed`
 
 ### `Dependencies`

--- a/docs/usage/tutorials.md
+++ b/docs/usage/tutorials.md
@@ -346,7 +346,9 @@ A detailed description can be found [here](https://github.com/bbuchfink/diamond/
 
 ### Kaiju custom database
 
-To build a kaiju database, you need three components: a FASTA file with the protein sequences, the NCBI taxonomy dump files, and you need to define the uppercase characters of the standard 20 amino acids you wish to include.
+A number of kaiju pre-built indexes for reference datasets are maintained by the the developers of kaiju and made available on the [kaiju website](https://bioinformatics-centre.github.io/kaiju/downloads.html). These databases can directly be used to run the workflow with Kaiju.
+
+In case the databases above do not contain your desired libraries, you can build a custom kaiju database. To build a kaiju database, you need three components: a FASTA file with the protein sequences, the NCBI taxonomy dump files, and you need to define the uppercase characters of the standard 20 amino acids you wish to include.
 
 :::warning
 The headers of the protein fasta file must be numeric NCBI taxon identifiers of the protein sequences.


### PR DESCRIPTION
<!--
# nf-core/taxprofiler pull request

Many thanks for contributing to nf-core/taxprofiler!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

I though out of consistency, it's good to also include pre-built kaiju databases. Similar to how Kraken databases are given.

- [X] This comment contains a description of changes (with reason).
- [X] Make sure your code lints (`nf-core lint`).
- [X] `CHANGELOG.md` is updated.
