### PR TITLE
Update Nonpareil to latest, add native MultiQC support, update output docs, fix MultiQC methods section

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -21,7 +21,7 @@ report_section_order:
     order: 700
   adapterRemoval:
     order: 600
-  nonpareil_all_samples:
+  nonpareil:
     order: 500
   porechop:
     order: 400
@@ -62,8 +62,7 @@ custom_logo_title: "nf-core/taxprofiler"
 run_modules:
   - fastqc
   - adapterRemoval
-  - fastp
-  - custom_content
+  - nonpareil
   - bbduk
   - prinseqplusplus
   - porechop
@@ -76,6 +75,7 @@ run_modules:
   - diamond
   - malt
   - motus
+  - custom_content
 
 sp:
   diamond:
@@ -85,12 +85,7 @@ sp:
   fastqc/zip:
     fn: "*_fastqc.zip"
   nonpareil_all_samples_mqc:
-    fn: "nonpareil_all_samples_mqc.png"
-
-custom_data:
-  nonpareil_all_samples:
-    section_name: "Nonpareil"
-    description: "Nonpareil uses the redundancy of the reads in metagenomic datasets to estimate the average coverage and predict the amount of sequences that will be required to achieve “nearly complete coverage”. Plots here are not interactive - being exported directly from the tool. If you have difficulty reading the plot, please see the individual PNG files in the results directory. DOI: https://doi.org/10.1128/mSystems.00039-18"
+    fn: "nonpareil_all_samples_mqc.json"
 
 top_modules:
   - "fastqc":
@@ -107,6 +102,7 @@ top_modules:
       path_filters_exclude:
         - "*raw*"
       extra: "If used in this run, Falco is a drop-in replacement for FastQC producing the same output, written by Guilherme de Sena Brandine and Andrew D. Smith."
+  - nonpareil
   - "porechop":
       name: "Porechop"
       anchor: "porechop"
@@ -185,24 +181,30 @@ table_columns_placement:
     percent_aligned: 370
     percent_collapsed: 380
     percent_discarded: 390
+  nonpareil:
+    nonpareil_R: 400
+    nonpareil_LR: 410
+    nonpareil_kappa: 420
+    nonpareil_C: 430
+    nonpareil_diversity: 440
   Porechop:
-    Input Reads: 400
-    Start Trimmed: 410
-    Start Trimmed Percent: 420
-    End Trimmed: 430
-    End Trimmed Percent: 440
-    Middle Split: 450
-    Middle Split Percent: 460
+    Input Reads: 500
+    Start Trimmed: 510
+    Start Trimmed Percent: 520
+    End Trimmed: 530
+    End Trimmed Percent: 540
+    Middle Split: 550
+    Middle Split Percent: 560
   Porechop_ABI:
-    Input Reads: 400
-    Start Trimmed: 410
-    Start Trimmed Percent: 420
-    End Trimmed: 430
-    End Trimmed Percent: 440
-    Middle Split: 450
-    Middle Split Percent: 460
+    Input Reads: 500
+    Start Trimmed: 510
+    Start Trimmed Percent: 520
+    End Trimmed: 530
+    End Trimmed Percent: 540
+    Middle Split: 550
+    Middle Split Percent: 560
   Filtlong:
-    Target bases: 500
+    Target bases: 600
   BBDuk:
     Input reads: 800
     Total Removed bases percent: 810
@@ -266,6 +268,24 @@ table_columns_visible:
     percent_duplicates: False
     percent_gc: False
     percent_fails: False
+  Adapter Removal:
+    aligned_total: True
+    percent_aligned: True
+    percent_collapsed: True
+    percent_discarded: False
+  fastp:
+    pct_adapter: True
+    pct_surviving: True
+    pct_duplication: False
+    after_filtering_gc_content: False
+    after_filtering_q30_rate: False
+    after_filtering_q30_bases: False
+  nonpareil:
+    nonpareil_R: false
+    nonpareil_LR: false
+    nonpareil_kappa: true
+    nonpareil_C: true
+    nonpareil_diversity: true
   porechop:
     Input reads: False
     Start Trimmed:
@@ -282,20 +302,8 @@ table_columns_visible:
     End Trimmed Percent: True
     Middle Split: False
     Middle Split Percent: True
-  fastp:
-    pct_adapter: True
-    pct_surviving: True
-    pct_duplication: False
-    after_filtering_gc_content: False
-    after_filtering_q30_rate: False
-    after_filtering_q30_bases: False
   Filtlong:
     Target bases: True
-  Adapter Removal:
-    aligned_total: True
-    percent_aligned: True
-    percent_collapsed: True
-    percent_discarded: False
   BBDuk:
     Input reads: False
     Total Removed bases Percent: False
@@ -349,6 +357,7 @@ extra_fn_clean_exts:
   - "_filtered"
   - "porechop"
   - "porechop_abi"
+  - "_processed"
   - type: remove
     pattern: "_falco"
 

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -62,7 +62,8 @@ custom_logo_title: "nf-core/taxprofiler"
 run_modules:
   - fastqc
   - adapterRemoval
-  - nonpareil
+    - fastp
+    - nonpareil
   - bbduk
   - prinseqplusplus
   - porechop

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -84,8 +84,8 @@ sp:
     fn_re: ".*(fastqc|falco)_data.txt$"
   fastqc/zip:
     fn: "*_fastqc.zip"
-  nonpareil_all_samples_mqc:
-    fn: "nonpareil_all_samples_mqc.json"
+  nonpareil:
+    fn: "nonpareil_all_samples.json"
 
 top_modules:
   - "fastqc":

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -227,7 +227,7 @@ process {
     }
 
     withName: 'NONPAREIL_NONPAREILCURVESR' {
-        ext.prefix = { "nonpareil_all_samples_mqc" }
+        ext.prefix = { "nonpareil_all_samples" }
         publishDir = [
             path: { "${params.outdir}/nonpareil/" },
             mode: params.publish_dir_mode,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -226,6 +226,15 @@ process {
         ]
     }
 
+    withName: 'NONPAREIL_NONPAREILCURVESR' {
+        ext.prefix = { "nonpareil_all_samples_mqc" }
+        publishDir = [
+            path: { "${params.outdir}/nonpareil/" },
+            mode: params.publish_dir_mode,
+            pattern: '*.{json,csv,tsv,pdf}'
+        ]
+    }
+
     // AdapterRemoval separate output merging
     withName: CAT_FASTQ {
         ext.prefix = { "${meta.id}_${meta.run_accession}" }

--- a/conf/test_fastp.config
+++ b/conf/test_fastp.config
@@ -20,28 +20,29 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                                 = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
-    databases                             = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
-    perform_shortread_qc                  = true
-    perform_longread_qc                   = true
-    shortread_qc_tool                     = 'fastp'
-    perform_shortread_complexityfilter    = true
-    shortread_complexityfilter_tool       = 'fastp'
-    perform_shortread_hostremoval         = true
-    perform_longread_hostremoval          = true
-    perform_runmerging                    = true
-    hostremoval_reference                 = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = true
-    run_kraken2                           = true
-    run_bracken                           = false
-    run_malt                              = false
-    run_metaphlan                         = false
-    run_centrifuge                        = false
-    run_diamond                           = false
-    run_krakenuniq                        = false
-    run_motus                             = false
-    run_ganon                             = false
-    run_kmcp                              = false
+    input                                   = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
+    databases                               = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
+    perform_shortread_qc                    = true
+    perform_longread_qc                     = true
+    shortread_qc_tool                       = 'fastp'
+    perform_shortread_redundancyestimation  = true
+    perform_shortread_complexityfilter      = true
+    shortread_complexityfilter_tool         = 'fastp'
+    perform_shortread_hostremoval           = true
+    perform_longread_hostremoval            = true
+    perform_runmerging                      = true
+    hostremoval_reference                   = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                               = true
+    run_kraken2                             = true
+    run_bracken                             = false
+    run_malt                                = false
+    run_metaphlan                           = false
+    run_centrifuge                          = false
+    run_diamond                             = false
+    run_krakenuniq                          = false
+    run_motus                               = false
+    run_ganon                               = false
+    run_kmcp                                = false
 }
 
 process {

--- a/conf/test_krakenuniq.config
+++ b/conf/test_krakenuniq.config
@@ -24,34 +24,35 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                                 = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
-    databases                             = params.pipelines_testdata_base_path + 'taxprofiler/database_krakenuniq.csv'
-    perform_shortread_qc                  = true
-    perform_longread_qc                   = true
-    shortread_qc_mergepairs               = true
-    perform_shortread_complexityfilter    = true
-    perform_shortread_hostremoval         = true
-    perform_longread_hostremoval          = true
-    perform_runmerging                    = true
-    hostremoval_reference                 = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = false
-    run_kraken2                           = false
-    run_bracken                           = false
-    run_malt                              = false
-    run_metaphlan                         = false
-    run_centrifuge                        = false
-    run_diamond                           = false
-    run_krakenuniq                        = true
-    run_motus                             = false
-    run_kmcp                              = false
-    run_ganon                             = false
-    run_krona                             = true
-    krona_taxonomy_directory              = params.pipelines_testdata_base_path + 'modules/data/genomics/sarscov2/metagenome/krona_taxonomy.tab'
-    malt_save_reads                       = false
-    kraken2_save_reads                    = false
-    centrifuge_save_reads                 = false
-    diamond_save_reads                    = false
-    run_profile_standardisation           = true
+    input                                   = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
+    databases                               = params.pipelines_testdata_base_path + 'taxprofiler/database_krakenuniq.csv'
+    perform_shortread_qc                    = true
+    perform_longread_qc                     = true
+    perform_shortread_redundancyestimation  = false
+    shortread_qc_mergepairs                 = true
+    perform_shortread_complexityfilter      = true
+    perform_shortread_hostremoval           = true
+    perform_longread_hostremoval            = true
+    perform_runmerging                      = true
+    hostremoval_reference                   = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                               = false
+    run_kraken2                             = false
+    run_bracken                             = false
+    run_malt                                = false
+    run_metaphlan                           = false
+    run_centrifuge                          = false
+    run_diamond                             = false
+    run_krakenuniq                          = true
+    run_motus                               = false
+    run_kmcp                                = false
+    run_ganon                               = false
+    run_krona                               = true
+    krona_taxonomy_directory                = params.pipelines_testdata_base_path + 'modules/data/genomics/sarscov2/metagenome/krona_taxonomy.tab'
+    malt_save_reads                         = false
+    kraken2_save_reads                      = false
+    centrifuge_save_reads                   = false
+    diamond_save_reads                      = false
+    run_profile_standardisation             = true
 }
 
 process {

--- a/conf/test_malt.config
+++ b/conf/test_malt.config
@@ -24,26 +24,27 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                                 = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet_malt.csv'
-    databases                             = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
-    perform_shortread_qc                  = false
-    perform_longread_qc                   = false
-    perform_shortread_complexityfilter    = false
-    perform_shortread_hostremoval         = false
-    perform_longread_hostremoval          = false
-    perform_runmerging                    = false
-    hostremoval_reference                 = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = false
-    run_kraken2                           = false
-    run_bracken                           = false
-    run_malt                              = true
-    run_metaphlan                         = false
-    run_centrifuge                        = false
-    run_diamond                           = false
-    run_krakenuniq                        = false
-    run_motus                             = false
-    run_ganon                             = false
-    run_kmcp                              = false
+    input                                   = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet_malt.csv'
+    databases                               = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
+    perform_shortread_qc                    = false
+    perform_longread_qc                     = false
+    perform_shortread_redundancyestimation  = false
+    perform_shortread_complexityfilter      = false
+    perform_shortread_hostremoval           = false
+    perform_longread_hostremoval            = false
+    perform_runmerging                      = false
+    hostremoval_reference                   = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                               = false
+    run_kraken2                             = false
+    run_bracken                             = false
+    run_malt                                = true
+    run_metaphlan                           = false
+    run_centrifuge                          = false
+    run_diamond                             = false
+    run_krakenuniq                          = false
+    run_motus                               = false
+    run_ganon                               = false
+    run_kmcp                                = false
 }
 
 process {

--- a/conf/test_motus.config
+++ b/conf/test_motus.config
@@ -24,30 +24,31 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                                 = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
-    databases                             = 'database_motus.csv'
-    perform_shortread_qc                  = false
-    perform_longread_qc                   = false
-    perform_shortread_complexityfilter    = false
-    perform_shortread_hostremoval         = false
-    perform_longread_hostremoval          = false
-    perform_runmerging                    = false
-    hostremoval_reference                 = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = false
-    run_kraken2                           = false
-    run_bracken                           = false
-    run_malt                              = false
-    run_metaphlan                         = false
-    run_centrifuge                        = false
-    run_diamond                           = false
-    run_krakenuniq                        = false
-    run_motus                             = true
-    run_kmcp                              = false
-    run_ganon                             = false
-    motus_save_mgc_read_counts            = false
-    motus_remove_ncbi_ids                 = false
-    motus_use_relative_abundance          = false
-    run_profile_standardisation           = true
+    input                                   = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
+    databases                               = 'database_motus.csv'
+    perform_shortread_qc                    = false
+    perform_longread_qc                     = false
+    perform_shortread_redundancyestimation  = false
+    perform_shortread_complexityfilter      = false
+    perform_shortread_hostremoval           = false
+    perform_longread_hostremoval            = false
+    perform_runmerging                      = false
+    hostremoval_reference                   = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                               = false
+    run_kraken2                             = false
+    run_bracken                             = false
+    run_malt                                = false
+    run_metaphlan                           = false
+    run_centrifuge                          = false
+    run_diamond                             = false
+    run_krakenuniq                          = false
+    run_motus                               = true
+    run_kmcp                                = false
+    run_ganon                               = false
+    motus_save_mgc_read_counts              = false
+    motus_remove_ncbi_ids                   = false
+    motus_use_relative_abundance            = false
+    run_profile_standardisation             = true
 }
 
 process {

--- a/conf/test_nopreprocessing.config
+++ b/conf/test_nopreprocessing.config
@@ -20,27 +20,28 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                                 = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
-    databases                             = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
-    perform_shortread_qc                  = false
-    perform_longread_qc                   = false
-    perform_shortread_complexityfilter    = false
-    perform_shortread_hostremoval         = false
-    perform_longread_hostremoval          = false
-    perform_runmerging                    = false
-    hostremoval_reference                 = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = true
-    run_kraken2                           = true
-    run_bracken                           = true
-    run_malt                              = false // too big with other profiles on GHA
-    run_metaphlan                         = true
-    run_centrifuge                        = true
-    run_diamond                           = true
-    run_krakenuniq                        = true
-    run_motus                             = false
-    run_kmcp                              = true
-    run_ganon                             = true
-    run_krona                             = true
+    input                                   = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
+    databases                               = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
+    perform_shortread_qc                    = false
+    perform_longread_qc                     = false
+    perform_shortread_redundancyestimation  = false
+    perform_shortread_complexityfilter      = false
+    perform_shortread_hostremoval           = false
+    perform_longread_hostremoval            = false
+    perform_runmerging                      = false
+    hostremoval_reference                   = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                               = true
+    run_kraken2                             = true
+    run_bracken                             = true
+    run_malt                                = false // too big with other profiles on GHA
+    run_metaphlan                           = true
+    run_centrifuge                          = true
+    run_diamond                             = true
+    run_krakenuniq                          = true
+    run_motus                               = false
+    run_kmcp                                = true
+    run_ganon                               = true
+    run_krona                               = true
 }
 
 process {

--- a/conf/test_noprofiling.config
+++ b/conf/test_noprofiling.config
@@ -20,27 +20,28 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                                 = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
-    databases                             = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
-    perform_shortread_qc                  = true
-    perform_longread_qc                   = true
-    shortread_qc_mergepairs               = true
-    perform_shortread_complexityfilter    = true
-    perform_shortread_hostremoval         = true
-    perform_longread_hostremoval          = true
-    perform_runmerging                    = true
-    hostremoval_reference                 = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = false
-    run_kraken2                           = false
-    run_bracken                           = false
-    run_malt                              = false
-    run_metaphlan                         = false
-    run_centrifuge                        = false
-    run_diamond                           = false
-    run_krakenuniq                        = false
-    run_motus                             = false
-    run_kmcp                              = false
-    run_ganon                             = false
+    input                                   = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
+    databases                               = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
+    perform_shortread_qc                    = true
+    perform_longread_qc                     = true
+    perform_shortread_redundancyestimation  = true
+    shortread_qc_mergepairs                 = true
+    perform_shortread_complexityfilter      = true
+    perform_shortread_hostremoval           = true
+    perform_longread_hostremoval            = true
+    perform_runmerging                      = true
+    hostremoval_reference                   = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                               = false
+    run_kraken2                             = false
+    run_bracken                             = false
+    run_malt                                = false
+    run_metaphlan                           = false
+    run_centrifuge                          = false
+    run_diamond                             = false
+    run_krakenuniq                          = false
+    run_motus                               = false
+    run_kmcp                                = false
+    run_ganon                               = false
 }
 
 process {

--- a/conf/test_nothing.config
+++ b/conf/test_nothing.config
@@ -20,26 +20,27 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                                 = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
-    databases                             = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
-    perform_shortread_qc                  = false
-    perform_longread_qc                   = false
-    perform_shortread_complexityfilter    = false
-    perform_shortread_hostremoval         = false
-    perform_longread_hostremoval          = false
-    perform_runmerging                    = false
-    hostremoval_reference                 = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = false
-    run_kraken2                           = false
-    run_bracken                           = false
-    run_malt                              = false
-    run_metaphlan                         = false
-    run_centrifuge                        = false
-    run_diamond                           = false
-    run_krakenuniq                        = false
-    run_motus                             = false
-    run_kmcp                              = false
-    run_ganon                             = false
+    input                                   = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
+    databases                               = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
+    perform_shortread_qc                    = false
+    perform_longread_qc                     = false
+    perform_shortread_redundancyestimation  = false
+    perform_shortread_complexityfilter      = false
+    perform_shortread_hostremoval           = false
+    perform_longread_hostremoval            = false
+    perform_runmerging                      = false
+    hostremoval_reference                   = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                               = false
+    run_kraken2                             = false
+    run_bracken                             = false
+    run_malt                                = false
+    run_metaphlan                           = false
+    run_centrifuge                          = false
+    run_diamond                             = false
+    run_krakenuniq                          = false
+    run_motus                               = false
+    run_kmcp                                = false
+    run_ganon                               = false
 }
 
 process {

--- a/conf/test_prinseqplusplus.config
+++ b/conf/test_prinseqplusplus.config
@@ -20,27 +20,28 @@ params {
     max_time   = '6.h'
 
     // Input data
-    input                                 = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
-    databases                             = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
-    perform_shortread_qc                  = true
-    perform_longread_qc                   = true
-    perform_shortread_complexityfilter    = true
-    shortread_complexityfilter_tool       = 'prinseqplusplus'
-    perform_shortread_hostremoval         = false
-    perform_longread_hostremoval          = false
-    perform_runmerging                    = false
-    hostremoval_reference                 = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
-    run_kaiju                             = true
-    run_kraken2                           = true
-    run_bracken                           = false
-    run_malt                              = false
-    run_metaphlan                         = false
-    run_centrifuge                        = false
-    run_diamond                           = false
-    run_krakenuniq                        = false
-    run_motus                             = false
-    run_ganon                             = false
-    run_kmcp                              = false
+    input                                  = params.pipelines_testdata_base_path + 'taxprofiler/samplesheet.csv'
+    databases                              = params.pipelines_testdata_base_path + 'taxprofiler/database_v1.1.csv'
+    perform_shortread_qc                   = true
+    perform_longread_qc                    = true
+    perform_shortread_redundancyestimation = false
+    perform_shortread_complexityfilter     = true
+    shortread_complexityfilter_tool        = 'prinseqplusplus'
+    perform_shortread_hostremoval          = false
+    perform_longread_hostremoval           = false
+    perform_runmerging                     = false
+    hostremoval_reference                  = params.pipelines_testdata_base_path + 'modules/data/genomics/homo_sapiens/genome/genome.fasta'
+    run_kaiju                              = true
+    run_kraken2                            = true
+    run_bracken                            = false
+    run_malt                               = false
+    run_metaphlan                          = false
+    run_centrifuge                         = false
+    run_diamond                            = false
+    run_krakenuniq                         = false
+    run_motus                              = false
+    run_ganon                              = false
+    run_kmcp                               = false
 }
 
 process {

--- a/docs/output.md
+++ b/docs/output.md
@@ -150,7 +150,8 @@ The resulting `.fastq` files may _not_ always be the 'final' reads that go into 
   - `<sample_id>.npa` - raw version of npo but with all replicates not just a summary (average) at each point. These three columns are: seq. effort (_n_ reads), replicate ID, redundancy value.
   - `<sample_id>.npc` - raw list with the number of reads in the dataset matching a query read.
   - `<sample_id>.png` - rendered version of a Nonpareil curve, with extrapolation and sequencing effort information.
-  - `nonpareil_all_samples_mqc.png` summary of plot of curves of all samples with sequencing effort information.
+  - `nonpareil_all_samples_mqc.{png,pdf}` summary of plot of curves of all samples with sequencing effort information.
+  - `nonpareil_all_samples_mqc.{json,tsv,csv}` basic summary statistics of model, with additional curve and plotting information in the JSON.
 
   </details>
 

--- a/docs/output.md
+++ b/docs/output.md
@@ -150,7 +150,7 @@ The resulting `.fastq` files may _not_ always be the 'final' reads that go into 
   - `<sample_id>.npa` - raw version of npo but with all replicates not just a summary (average) at each point. These three columns are: seq. effort (_n_ reads), replicate ID, redundancy value.
   - `<sample_id>.npc` - raw list with the number of reads in the dataset matching a query read.
   - `<sample_id>.png` - rendered version of a Nonpareil curve, with extrapolation and sequencing effort information.
-  - `nonpareil_all_samples_mqc.{png,pdf}` summary of plot of curves of all samples with sequencing effort information.
+  - `nonpareil_all_samples_mqc.{png,pdf}` summary of the plot of curves for all samples with sequencing effort information.
   - `nonpareil_all_samples_mqc.{json,tsv,csv}` basic summary statistics of model, with additional curve and plotting information in the JSON.
 
   </details>

--- a/modules.json
+++ b/modules.json
@@ -202,17 +202,22 @@
                     },
                     "nonpareil/curve": {
                         "branch": "master",
-                        "git_sha": "729335dda8ba226323edc54dec80ae959079207e",
+                        "git_sha": "3e403b703c04d4af6bddb4f0b03b772b7365ffc0",
                         "installed_by": ["modules"]
                     },
                     "nonpareil/nonpareil": {
                         "branch": "master",
-                        "git_sha": "b5b76d170586dfa39cbd9be3043d53d827cfb68d",
+                        "git_sha": "3f2fe668ac15c5292eb123f86104bc9ed96c3eed",
+                        "installed_by": ["modules"]
+                    },
+                    "nonpareil/nonpareilcurvesr": {
+                        "branch": "master",
+                        "git_sha": "3e403b703c04d4af6bddb4f0b03b772b7365ffc0",
                         "installed_by": ["modules"]
                     },
                     "nonpareil/set": {
                         "branch": "master",
-                        "git_sha": "729335dda8ba226323edc54dec80ae959079207e",
+                        "git_sha": "3e403b703c04d4af6bddb4f0b03b772b7365ffc0",
                         "installed_by": ["modules"]
                     },
                     "porechop/abi": {

--- a/modules/nf-core/nonpareil/curve/environment.yml
+++ b/modules/nf-core/nonpareil/curve/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::nonpareil=3.4.1
+  - bioconda::nonpareil=3.5.5

--- a/modules/nf-core/nonpareil/curve/main.nf
+++ b/modules/nf-core/nonpareil/curve/main.nf
@@ -4,8 +4,8 @@ process NONPAREIL_CURVE {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nonpareil:3.4.1--r42h9f5acd7_2':
-        'biocontainers/nonpareil:3.4.1--r42h9f5acd7_2' }"
+        'https://depot.galaxyproject.org/singularity/nonpareil:3.5.5--r43hdcf5f25_0':
+        'biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
 
     input:
     tuple val(meta), path(npo)

--- a/modules/nf-core/nonpareil/curve/meta.yml
+++ b/modules/nf-core/nonpareil/curve/meta.yml
@@ -1,7 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: "nonpareil_curve"
-description: Visualise metagenome redundancy curve from a single Nonpareil npo file
+description: Visualise metagenome redundancy curve in PNG format from a single Nonpareil npo file
 keywords:
   - metagenomics
   - statistics
@@ -38,7 +38,7 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
-  - npa:
+  - png:
       type: file
       description: PNG file of the Nonpareil curve
       pattern: "*.png"

--- a/modules/nf-core/nonpareil/curve/tests/main.nf.test
+++ b/modules/nf-core/nonpareil/curve/tests/main.nf.test
@@ -8,25 +8,25 @@ nextflow_process {
     tag "modules_nfcore"
     tag "nonpareil"
     tag "nonpareil/curve"
+    tag "nonpareil/nonpareil"
 
-    test("candidatus_portiera_aleyrodidarum") {
-
-
-        setup {
-            run("NONPAREIL_NONPAREIL") {
-                script "../../../nonpareil/nonpareil/main.nf"
-                process {
-                    """
-                    input[0] = [
-                        [ id:'test', single_end:false ], // meta map
-                        file(params.test_data['candidatus_portiera_aleyrodidarum']['illumina']['test_1_fastq_gz'], checkIfExists: true)
-                    ]
-                    input[1] = 'fastq'
-                    input[2] = 'kmer'
-                    """
-                }
+    setup {
+        run("NONPAREIL_NONPAREIL") {
+            script "../../../nonpareil/nonpareil/main.nf"
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.test_data['candidatus_portiera_aleyrodidarum']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                ]
+                input[1] = 'fastq'
+                input[2] = 'kmer'
+                """
             }
         }
+    }
+
+    test("candidatus_portiera_aleyrodidarum") {
 
         when {
             process {
@@ -40,10 +40,34 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                        file(process.out.png[0][1]).name,
+                    process.out.versions,
+                    file(process.out.png[0][1]).name,
                     ).match()
-                },
-                { assert snapshot(process.out.versions).match("versions") },
+                }
+            )
+        }
+
+    }
+
+    test("candidatus_portiera_aleyrodidarum - stub") {
+
+        options "-stub"
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = NONPAREIL_NONPAREIL.out.npo
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(process.out).match() }
             )
         }
 

--- a/modules/nf-core/nonpareil/curve/tests/main.nf.test.snap
+++ b/modules/nf-core/nonpareil/curve/tests/main.nf.test.snap
@@ -1,16 +1,50 @@
 {
-    "versions": {
-        "content": [
-            [
-                "versions.yml:md5,4fd5056eb19ba567feeb415f838467c8"
-            ]
-        ],
-        "timestamp": "2023-11-15T15:06:56.417163251"
-    },
     "candidatus_portiera_aleyrodidarum": {
         "content": [
+            [
+                "versions.yml:md5,591a0a74569106b79c101d0059a822ad"
+            ],
             "test.png"
         ],
-        "timestamp": "2023-11-15T15:06:56.414621918"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T12:11:37.549218924"
+    },
+    "candidatus_portiera_aleyrodidarum - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,ea8a60928f2d6fb3fe8895b63fba42f4"
+                ],
+                "png": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,ea8a60928f2d6fb3fe8895b63fba42f4"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T14:32:21.066752297"
     }
 }

--- a/modules/nf-core/nonpareil/curve/tests/nextflow.config
+++ b/modules/nf-core/nonpareil/curve/tests/nextflow.config
@@ -1,7 +1,4 @@
 process {
-
-    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-
     withName: NONPAREIL_NONPAREIL {
         ext.args = '-X 100'
     }

--- a/modules/nf-core/nonpareil/nonpareil/environment.yml
+++ b/modules/nf-core/nonpareil/nonpareil/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::nonpareil=3.4.1
+  - bioconda::nonpareil=3.5.5

--- a/modules/nf-core/nonpareil/nonpareil/tests/main.nf.test
+++ b/modules/nf-core/nonpareil/nonpareil/tests/main.nf.test
@@ -8,14 +8,11 @@ nextflow_process {
     tag "modules_nfcore"
     tag "nonpareil"
     tag "nonpareil/nonpareil"
+    tag "gunzip"
 
     test("candidatus_portiera_aleyrodidarum - gzipped") {
 
         when {
-            params {
-                // define parameters here. Example:
-            // outdir = "tests/results"
-            }
             process {
                 """
                 input[0] = [
@@ -35,10 +32,10 @@ nextflow_process {
                         file(process.out.npa[0][1]).name,
                         file(process.out.npc[0][1]).name,
                         path(process.out.npo[0][1]).readLines()[0],
-                        path(process.out.npl[0][1])
+                        path(process.out.npl[0][1]).readLines().last().contains("Everything seems correct"),
+                        process.out.versions
                     ).match()
-                },
-                { assert snapshot(process.out.versions).match("versions") },
+                }
             )
         }
 
@@ -62,10 +59,6 @@ nextflow_process {
         }
 
         when {
-            params {
-                // define parameters here. Example:
-            // outdir = "tests/results"
-            }
             process {
                 """
                 input[0] = GUNZIP.out.gunzip
@@ -82,13 +75,40 @@ nextflow_process {
                         file(process.out.npa[0][1]).name,
                         file(process.out.npc[0][1]).name,
                         path(process.out.npo[0][1]).readLines()[0],
-                        path(process.out.npl[0][1])
+                        path(process.out.npl[0][1]).readLines().last().contains("Everything seems correct"),
+                        process.out.versions
                     ).match()
-                },
-                { assert snapshot(process.out.versions).match("versions") },
+                }
             )
         }
 
     }
+
+test("candidatus_portiera_aleyrodidarum - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    file(params.test_data['candidatus_portiera_aleyrodidarum']['illumina']['test_1_fastq_gz'], checkIfExists: true)
+                ]
+                input[1] = 'fastq'
+                input[2] = 'kmer'
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
 
 }

--- a/modules/nf-core/nonpareil/nonpareil/tests/main.nf.test.snap
+++ b/modules/nf-core/nonpareil/nonpareil/tests/main.nf.test.snap
@@ -4,25 +4,120 @@
             "test.npa",
             "test.npc",
             "# @impl: Nonpareil",
-            "test.npl:md5,be95453a272a9f685d5695d2b391fde8"
-        ],
-        "timestamp": "2023-11-15T15:01:09.813985564"
-    },
-    "versions": {
-        "content": [
+            true,
             [
-                "versions.yml:md5,e0ced37a70dc4c48f079114388b2b9c4"
+                "versions.yml:md5,5a5e1b70e05a4637015adbfaeac017fd"
             ]
         ],
-        "timestamp": "2023-11-15T15:01:02.296717365"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T14:11:57.001694911"
     },
     "candidatus_portiera_aleyrodidarum - gzipped": {
         "content": [
             "test.npa",
             "test.npc",
             "# @impl: Nonpareil",
-            "test.npl:md5,be95453a272a9f685d5695d2b391fde8"
+            true,
+            [
+                "versions.yml:md5,5a5e1b70e05a4637015adbfaeac017fd"
+            ]
         ],
-        "timestamp": "2023-11-15T15:01:02.2871395"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T14:11:49.888813434"
+    },
+    "candidatus_portiera_aleyrodidarum - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npc:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npo:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,5a5e1b70e05a4637015adbfaeac017fd"
+                ],
+                "npa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npa:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "npc": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npc:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "npl": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npl:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "npo": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npo:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,5a5e1b70e05a4637015adbfaeac017fd"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T14:38:09.784957219"
     }
 }

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/environment.yml
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/environment.yml
@@ -1,0 +1,9 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/environment-schema.json
+name: "nonpareil_nonpareilcurvesr"
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - "bioconda::nonpareil=3.5.5"

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/meta.yml
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/meta.yml
@@ -1,0 +1,63 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
+name: "nonpareil_nonpareilcurvesr"
+description: Generate summary reports with raw data for Nonpareil NPO curves, including MultiQC compatible JSON/TSV files
+keywords:
+  - metagenomics
+  - statistics
+  - coverage
+  - redundancy
+  - diversity
+  - complexity
+  - multiqc
+tools:
+  - "nonpareil":
+      description: "Estimate average coverage and create curves for metagenomic datasets"
+      homepage: "https://github.com/lmrodriguezr/nonpareil"
+      documentation: "https://nonpareil.readthedocs.io/en/latest/"
+      tool_dev_url: "https://github.com/lmrodriguezr/nonpareil"
+      doi: "10.1128/msystems.00039-"
+      licence: ["Artistic License 2.0"]
+
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1', single_end:false ]`
+  - npos:
+      type: file
+      description: One or a list of Nonpareil NPO files (From nonpareil/nonpareil)
+      pattern: "*.{npo}"
+
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. `[ id:'sample1', single_end:false ]`
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - json:
+      type: file
+      description: Raw nonpareil data used for generating and plotting curves in JSON format
+      pattern: "*.json"
+  - tsv:
+      type: file
+      description: Raw nonpareil data used for generating and plotting curves in JSON format
+      pattern: "*.tsv"
+  - csv:
+      type: file
+      description: Raw nonpareil data used for generating and plotting curves in JSON format
+      pattern: "*.csv"
+  - pdf:
+      type: file
+      description: Plotted nonpareil curves in PDF format
+      pattern: "*.pdf"
+
+authors:
+  - "@jfy133"
+maintainers:
+  - "@jfy133"

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/tests/main.nf.test
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/tests/main.nf.test
@@ -1,13 +1,13 @@
 nextflow_process {
 
-    name "Test Process NONPAREIL_SET"
+    name "Test Process NONPAREIL_NONPAREILCURVESR"
     script "../main.nf"
-    process "NONPAREIL_SET"
-    config "./nextflow.config"
+    process "NONPAREIL_NONPAREILCURVESR"
+
     tag "modules"
     tag "modules_nfcore"
     tag "nonpareil"
-    tag "nonpareil/set"
+    tag "nonpareil/nonpareilcurvesr"
     tag "nonpareil/nonpareil"
 
     setup {
@@ -40,7 +40,10 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                        file(process.out.png[0][1]).name,
+                        path(process.out.json[0][1]).text.contains("modelR\": 0."),
+                        path(process.out.tsv[0][1]).text.contains("test	0."),
+                        path(process.out.csv[0][1]).text.contains("test\",0."),
+                        file(process.out.pdf[0][1]).name,
                         process.out.versions
                     ).match()
                 }
@@ -49,7 +52,7 @@ nextflow_process {
 
     }
 
-test("candidatus_portiera_aleyrodidarum - stub") {
+    test("candidatus_portiera_aleyrodidarum - stub") {
 
         options "-stub"
 

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/tests/main.nf.test.snap
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/tests/main.nf.test.snap
@@ -1,0 +1,99 @@
+{
+    "candidatus_portiera_aleyrodidarum": {
+        "content": [
+            true,
+            true,
+            true,
+            "test.pdf",
+            [
+                "versions.yml:md5,9aae4700a1ceafa37850be8d82d8d6dc"
+            ]
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-08T12:14:04.694169651"
+    },
+    "candidatus_portiera_aleyrodidarum - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "2": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "3": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "4": [
+                    "versions.yml:md5,9aae4700a1ceafa37850be8d82d8d6dc"
+                ],
+                "csv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "json": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "pdf": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,9aae4700a1ceafa37850be8d82d8d6dc"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-08T12:03:11.519050978"
+    }
+}

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/tests/tags.yml
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/tests/tags.yml
@@ -1,0 +1,2 @@
+nonpareil/nonpareilcurvesr:
+  - "modules/nf-core/nonpareil/nonpareilcurvesr/**"

--- a/modules/nf-core/nonpareil/set/environment.yml
+++ b/modules/nf-core/nonpareil/set/environment.yml
@@ -4,4 +4,4 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - bioconda::nonpareil=3.4.1
+  - bioconda::nonpareil=3.5.5

--- a/modules/nf-core/nonpareil/set/main.nf
+++ b/modules/nf-core/nonpareil/set/main.nf
@@ -4,8 +4,8 @@ process NONPAREIL_SET {
 
     conda "${moduleDir}/environment.yml"
     container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/nonpareil:3.4.1--r42h9f5acd7_2':
-        'biocontainers/nonpareil:3.4.1--r42h9f5acd7_2' }"
+        'https://depot.galaxyproject.org/singularity/nonpareil:3.5.5--r43hdcf5f25_0':
+        'biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
 
     input:
     tuple val(meta), path(npos)

--- a/modules/nf-core/nonpareil/set/meta.yml
+++ b/modules/nf-core/nonpareil/set/meta.yml
@@ -1,7 +1,7 @@
 ---
 # yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: "nonpareil_set"
-description: Visualise metagenome redundancy curves from multiple Nonpareil npo file in a single image
+description: Visualise metagenome redundancy curves in PNG format from multiple Nonpareil npo files in a single image
 keywords:
   - metagenomics
   - statistics
@@ -24,7 +24,7 @@ input:
       description: |
         Groovy Map containing sample information
         e.g. `[ id:'test', single_end:false ]`
-  - npo:
+  - npos:
       type: file
       description: A list of npo redundancy summary files from nonpareil itself
       pattern: "*.npo"
@@ -38,7 +38,7 @@ output:
       type: file
       description: File containing software versions
       pattern: "versions.yml"
-  - npa:
+  - png:
       type: file
       description: PNG file of all the Nonpareil curves of the input npo files
       pattern: "*.png"

--- a/modules/nf-core/nonpareil/set/tests/main.nf.test.snap
+++ b/modules/nf-core/nonpareil/set/tests/main.nf.test.snap
@@ -1,16 +1,48 @@
 {
-    "versions": {
-        "content": [
-            [
-                "versions.yml:md5,14de8687316f361bf9bf68b7d52d1d0a"
-            ]
-        ],
-        "timestamp": "2023-11-21T10:00:14.264709081"
-    },
     "candidatus_portiera_aleyrodidarum": {
         "content": [
-            "test.png"
+            "test.png",
+            [
+                "versions.yml:md5,99b7abbea8d46b0a3d15ecd35049dc8d"
+            ]
         ],
-        "timestamp": "2023-11-21T10:00:14.259656292"
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T12:12:45.998873423"
+    },
+    "candidatus_portiera_aleyrodidarum - stub": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "1": [
+                    "versions.yml:md5,e12f68cd2102c6ab64e888bec3c7e7aa"
+                ],
+                "png": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions": [
+                    "versions.yml:md5,e12f68cd2102c6ab64e888bec3c7e7aa"
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.8.4",
+            "nextflow": "24.04.4"
+        },
+        "timestamp": "2024-08-07T14:40:53.480864245"
     }
 }

--- a/modules/nf-core/nonpareil/set/tests/nextflow.config
+++ b/modules/nf-core/nonpareil/set/tests/nextflow.config
@@ -1,7 +1,5 @@
 process {
 
-    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-
     withName: NONPAREIL_NONPAREIL {
         ext.args = '-X 100'
     }

--- a/subworkflows/local/nonpareil.nf
+++ b/subworkflows/local/nonpareil.nf
@@ -1,6 +1,7 @@
-include { NONPAREIL_NONPAREIL } from '../../modules/nf-core/nonpareil/nonpareil/main'
-include { NONPAREIL_CURVE     } from '../../modules/nf-core/nonpareil/curve/main'
-include { NONPAREIL_SET       } from '../../modules/nf-core/nonpareil/set/main'
+include { NONPAREIL_NONPAREIL        } from '../../modules/nf-core/nonpareil/nonpareil/main'
+include { NONPAREIL_CURVE            } from '../../modules/nf-core/nonpareil/curve/main'
+include { NONPAREIL_SET              } from '../../modules/nf-core/nonpareil/set/main'
+include { NONPAREIL_NONPAREILCURVESR } from '../../modules/nf-core/nonpareil/nonpareilcurvesr/main'
 
 // Custom Functions
 
@@ -41,17 +42,32 @@ workflow NONPAREIL {
                                         format: format
                                 }
 
+    // Calculation
     NONPAREIL_NONPAREIL( ch_reads_for_nonpareil.reads, ch_reads_for_nonpareil.format, params.shortread_redundancyestimation_mode)
-    NONPAREIL_CURVE ( NONPAREIL_NONPAREIL.out.npo )
-    NONPAREIL_SET ( NONPAREIL_NONPAREIL.out.npo.map {meta, npo -> [[id: 'all'], npo] }.groupTuple() )
 
-    ch_versions = ch_versions.mix( NONPAREIL_NONPAREIL.out.versions.first(), NONPAREIL_CURVE.out.versions.first(), NONPAREIL_SET.out.versions.first() )
-    ch_multiqc_files = ch_multiqc_files.mix( NONPAREIL_SET.out.png )
+    ch_npos_for_nonparielset = NONPAREIL_NONPAREIL.out.npo
+                                .map {meta, npo -> [[id: 'all'], npo] }
+                                .groupTuple()
+
+    // Plotting
+    NONPAREIL_CURVE            ( NONPAREIL_NONPAREIL.out.npo ) // For static single-curve PNG
+    NONPAREIL_SET              ( ch_npos_for_nonparielset ) // For static multi-curve PNG
+    NONPAREIL_NONPAREILCURVESR ( ch_npos_for_nonparielset ) // For dynamic multi-curve PNG in MultiQC and raw files
+
+    ch_versions = ch_versions
+                    .mix(
+                        NONPAREIL_NONPAREIL.out.versions.first(),
+                        NONPAREIL_CURVE.out.versions.first(),
+                        NONPAREIL_SET.out.versions.first(),
+                        NONPAREIL_NONPAREILCURVESR.out.versions.first()
+                    )
+    ch_multiqc_files = ch_multiqc_files.mix( NONPAREIL_NONPAREILCURVESR.out.json )
 
     emit:
-    npo        = NONPAREIL_NONPAREIL.out.npo
-    curve_pngs = NONPAREIL_CURVE.out.png
-    set_pngs   = NONPAREIL_CURVE.out.png
-    versions   = ch_versions
-    mqc        = ch_multiqc_files
+    npo              = NONPAREIL_NONPAREIL.out.npo
+    curve_pngs       = NONPAREIL_CURVE.out.png
+    set_pngs         = NONPAREIL_SET.out.png
+    nonpareilcurvesr = NONPAREIL_NONPAREILCURVESR.out.tsv
+    versions         = ch_versions
+    mqc              = ch_multiqc_files
 }

--- a/subworkflows/local/utils_nfcore_taxprofiler_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_taxprofiler_pipeline/main.nf
@@ -192,7 +192,7 @@ def genomeExistsError() {
 //
 def toolCitationText() {
     def text_seq_qc = [
-        "Sequencing quality control was carried out with:",
+        "Sequencing quality control with",
         params.preprocessing_qc_tool == "falco" ? "Falco (de Sena Brandine and Smith 2021)." : "FastQC (Andrews 2010)."
     ].join(' ').trim()
 
@@ -209,9 +209,9 @@ def toolCitationText() {
 
     def text_longread_qc = [
         "Long read preprocessing was performed with:",
-        params.longread_adapterremoval_tool == "porechop_abi" ? "Porechop_ABI (Bonenfant et al. 2023)." : "",
-        params.longread_adapterremoval_tool == "porechop" ? "Porechop (Wick et al. 2017)." : "",
-        params.longread_filter_tool == "filtlong" ? "Filtlong (Wick 2021)." : "",
+        params.longread_adapterremoval_tool == "porechop_abi" ? "Porechop_ABI (Bonenfant et al. 2023)," : "",
+        params.longread_adapterremoval_tool == "porechop" ? "Porechop (Wick et al. 2017)," : "",
+        params.longread_filter_tool == "filtlong" ? "Filtlong (Wick 2021)," : "",
         params.longread_filter_tool == "nanoq" ? "Nanoq (Steinig and Coin 2022)." : "",
     ].join(' ').trim()
 
@@ -264,7 +264,8 @@ def toolCitationText() {
         params.perform_shortread_complexityfilter       ? text_shortreadcomplexity : "",
         params.perform_shortread_hostremoval            ? text_shortreadhostremoval : "",
         params.perform_longread_hostremoval             ? text_longreadhostremoval : "",
-        text_classification,
+        [params.run_bracken, params.run_kraken2, params.run_krakenuniq, params.run_metaphlan, params.run_malt, params.run_diamond, params.run_centrifuge, params.run_kaiju, params.run_motus, params.run_ganon, params.run_kmcp].any() ?
+            text_classification : "",
         params.run_krona                                ? text_visualisation : "",
         params.run_profile_standardisation              ? text_postprocessing : "",
         "Pipeline results statistics were summarised with MultiQC (Ewels et al. 2016)."
@@ -375,13 +376,11 @@ def methodsDescriptionText( mqc_methods_yaml ) {
     } else meta["doi_text"] = ""
     meta["nodoi_text"] = meta.manifest_map.doi ? "" : "<li>If available, make sure to update the text to include the Zenodo DOI of version of the pipeline used. </li>"
 
-    meta["tool_citations"] = ""
-    meta["tool_bibliography"] = ""
+    // meta["tool_citations"] = ""
+    // meta["tool_bibliography"] = ""
 
-    // TODO nf-core: Only uncomment below if logic in toolCitationText/toolBibliographyText has been filled!
-    // meta["tool_citations"] = toolCitationText().replaceAll(", \\.", ".").replaceAll("\\. \\.", ".").replaceAll(", \\.", ".")
-    // meta["tool_bibliography"] = toolBibliographyText()
-
+    meta["tool_citations"] = toolCitationText().replaceAll(", \\.", ".").replaceAll("\\. \\.", ".").replaceAll(", \\.", ".")
+    meta["tool_bibliography"] = toolBibliographyText()
 
     def methods_text = mqc_methods_yaml.text
 


### PR DESCRIPTION
This removes the static PNG MultiQC section for Nonpareil and replaces with the interactive 'native' MultiQC plot (thanks again @fgvieira and @lmrodriguezr <3) , which involves a module/version bump update.

I also noticed the MultiQC methods were a bit borked producing incomplete text, this is updated now.

MultiQC HTML is from `noprofiling` test profile as an example.

[multiqc.zip](https://github.com/user-attachments/files/16573499/multiqc.zip).

closes #502 

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
