### PR TITLE
Remove links to multiqc plots

### DIFF
--- a/docs/output.md
+++ b/docs/output.md
@@ -80,16 +80,6 @@ If preprocessing is turned on, nf-core/taxprofiler runs FastQC/Falco twice -once
 Falco produces identical output to FastQC but in the `falco/` directory.
 :::
 
-![MultiQC - FastQC sequence counts plot](images/mqc_fastqc_counts.png)
-
-![MultiQC - FastQC mean quality scores plot](images/mqc_fastqc_quality.png)
-
-![MultiQC - FastQC adapter content plot](images/mqc_fastqc_adapter.png)
-
-:::note
-The FastQC plots displayed in the MultiQC report shows _untrimmed_ reads. They may contain adapter sequence and potentially regions with low quality.
-:::
-
 ### fastp
 
 [fastp](https://github.com/OpenGene/fastp) is a FASTQ pre-processing tool for quality control, trimmming of adapters, quality filtering and other features.


### PR DESCRIPTION
took me a bit to figure out that it wasn't actually problematic website rendering that didn't render the images 😁 

Probably a merge artifact from a template update?