### PR TITLE
Fix: increase log_filesize_limit in MultiQC config for high-coverage samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 ### `Fixed`
-
+### `Fixed`
+- [#736](https://github.com/nf-core/taxprofiler/issues/#736) Fix MultiQC silently skipping large samtools stats files by increasing `log_filesize_limit` in MultiQC config (reported by @Leilanasd)
 ### `Changed`
 
 ### `Deprecated`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### `Added`
 
 ### `Fixed`
-### `Fixed`
-- [#736](https://github.com/nf-core/taxprofiler/issues/#736) Fix MultiQC silently skipping large samtools stats files by increasing `log_filesize_limit` in MultiQC config (reported by @Leilanasd)
+
+- [#736](https://github.com/nf-core/taxprofiler/issues/736) Fix MultiQC silently skipping large samtools stats files by increasing `log_filesize_limit` in MultiQC config (reported and fixed by @Leilanasd)
+
 ### `Changed`
 
 ### `Deprecated`

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ We thank the following people for their contributions to the development of this
 - [Alex Caswell](https://github.com/AlexHoratio)
 - [Aidan Epstein](https://github.com/epstein6)
 - [Efthymios Parisis](https://github.com/eparisis)
+- [Leila Nasirzadeh](https://github.com/Leilanasd)
 
 ### Acknowledgments
 

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -55,6 +55,7 @@ report_section_order:
 export_plots: true
 
 disable_version_detection: true
+log_filesize_limit: 500000000
 custom_logo: "nf-core-taxprofiler_logo_custom_light.png"
 custom_logo_url: https://nf-co.re/taxprofiler
 custom_logo_title: "nf-core/taxprofiler"


### PR DESCRIPTION
Fixes the issue where high-coverage samples are silently missing from the 
Samtools Stats section in the MultiQC report when using long-read host removal.

The root cause is MultiQC's default `log_filesize_limit` of 50MB. Samtools stats 
files from high-coverage Nanopore samples mapped to a large reference genome can 
exceed this, causing them to be silently skipped with no warning.

Fix: added  log_filesize_limit: 500000000 to assets/multiqc_config.yml 


## PR checklist

- [X] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/taxprofiler/tree/main/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/taxprofiler _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ X] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
