### PR TITLE
Fix broken developing docs link to CONTRIBUTING.md

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ In addition to this page, you can find additional usage information on the follo
 
 - [Tutorials](usage/tutorials.md)
 - [FAQ and Troubleshooting](usage/faq-troubleshooting.md)
-- [Developing](usage/developing.md)
+- [Developing](https://github.com/nf-core/taxprofiler/blob/2.0.1/docs/CONTRIBUTING.md)
 
 ## General Usage
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -12,7 +12,7 @@ In addition to this page, you can find additional usage information on the follo
 
 - [Tutorials](usage/tutorials.md)
 - [FAQ and Troubleshooting](usage/faq-troubleshooting.md)
-- [Developing](https://github.com/nf-core/taxprofiler/blob/2.0.1/docs/CONTRIBUTING.md)
+- [Developing](https://github.com/nf-core/taxprofiler/blob/dev/docs/CONTRIBUTING.md)
 
 ## General Usage
 


### PR DESCRIPTION
Fix contributing link for developing-docs-link. Updated the link to point to the CONTRIBUTING.md  in github.