### PR TITLE
Fixes Nextflow strict-syntax warnings raised by nextflow lint main.nf.

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -48,7 +48,7 @@ workflow NFCORE_TAXPROFILER {
     )
 
     emit:
-    multiqc_report = TAXPROFILER.out.multiqc_report // channel: /path/to/multiqc_report.html
+        TAXPROFILER.out.multiqc_report // channel: /path/to/multiqc_report.html
 }
 
 

--- a/main.nf
+++ b/main.nf
@@ -48,7 +48,7 @@ workflow NFCORE_TAXPROFILER {
     )
 
     emit:
-        TAXPROFILER.out.multiqc_report // channel: /path/to/multiqc_report.html
+    multiqc_report = TAXPROFILER.out.multiqc_report // channel: /path/to/multiqc_report.html
 }
 
 

--- a/modules.json
+++ b/modules.json
@@ -12,7 +12,7 @@
                     },
                     "bbmap/bbduk": {
                         "branch": "master",
-                        "git_sha": "3351c212144fc8aab0e595165bf447ebecfebd8a",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "bowtie2/align": {
@@ -27,17 +27,17 @@
                     },
                     "bracken/bracken": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "bracken/combinebrackenoutputs": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "cat/fastq": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "centrifuge/centrifuge": {
@@ -50,16 +50,6 @@
                         "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
                         "installed_by": ["modules"]
                     },
-                    "deacon/filter": {
-                        "branch": "master",
-                        "git_sha": "719abfd0ec41bcc7e2f540b4fd5c8150fdfe228e",
-                        "installed_by": ["modules"]
-                    },
-                    "deacon/index": {
-                        "branch": "master",
-                        "git_sha": "719abfd0ec41bcc7e2f540b4fd5c8150fdfe228e",
-                        "installed_by": ["modules"]
-                    },
                     "centrifuger/centrifuger": {
                         "branch": "master",
                         "git_sha": "fd621e0378a3692aa31943d0d4bd49c435b9efcf",
@@ -68,6 +58,16 @@
                     "centrifuger/quantification": {
                         "branch": "master",
                         "git_sha": "fd621e0378a3692aa31943d0d4bd49c435b9efcf",
+                        "installed_by": ["modules"]
+                    },
+                    "deacon/filter": {
+                        "branch": "master",
+                        "git_sha": "719abfd0ec41bcc7e2f540b4fd5c8150fdfe228e",
+                        "installed_by": ["modules"]
+                    },
+                    "deacon/index": {
+                        "branch": "master",
+                        "git_sha": "719abfd0ec41bcc7e2f540b4fd5c8150fdfe228e",
                         "installed_by": ["modules"]
                     },
                     "diamond/blastx": {
@@ -97,22 +97,22 @@
                     },
                     "ganon/classify": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "ganon/report": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "ganon/table": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "gunzip": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "0902eac3012baaf4f9ab6513c8c55acc9353c96c",
                         "installed_by": ["modules"]
                     },
                     "hostile/clean": {
@@ -127,42 +127,42 @@
                     },
                     "kaiju/kaiju": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "5e510d0648e0d7fecd3b359fd2a7e59b36744b21",
                         "installed_by": ["modules"]
                     },
                     "kaiju/kaiju2krona": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "5e510d0648e0d7fecd3b359fd2a7e59b36744b21",
                         "installed_by": ["modules"]
                     },
                     "kaiju/kaiju2table": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "5e510d0648e0d7fecd3b359fd2a7e59b36744b21",
                         "installed_by": ["modules"]
                     },
                     "kmcp/profile": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "5c7b45afd4f0c480f7290c9527552f28d53852f4",
                         "installed_by": ["modules"]
                     },
                     "kmcp/search": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "5c7b45afd4f0c480f7290c9527552f28d53852f4",
                         "installed_by": ["modules"]
                     },
                     "kraken2/kraken2": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "d67d33d5925fcec4691b499670fa2bd926fd2be5",
                         "installed_by": ["modules"]
                     },
                     "krakentools/combinekreports": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "03bd94fc81b464595bcef5d9dc3f06ea1f34bfa0",
                         "installed_by": ["modules"]
                     },
                     "krakentools/kreport2krona": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "03bd94fc81b464595bcef5d9dc3f06ea1f34bfa0",
                         "installed_by": ["modules"]
                     },
                     "krakenuniq/preloadedkrakenuniq": {
@@ -182,37 +182,37 @@
                     },
                     "malt/run": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "70a5a677f10ea745e43e0f6c4bb15a2fb3cc7892",
                         "installed_by": ["modules"]
                     },
                     "megan/rma2info": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6fa66f7fe3dd563ff31dc69e6797e88d3e2093e8",
                         "installed_by": ["modules"]
                     },
                     "melon": {
                         "branch": "master",
-                        "git_sha": "83fe5c85a83aae68a6eb0561e04cbba1e153ac5a",
+                        "git_sha": "63cffe4cd2f2ff455d13b7ce3054b9d68a4a6078",
                         "installed_by": ["modules"]
                     },
                     "metacache/query": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "metaphlan/mergemetaphlantables": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "98ad2ea364508c5eefa3eee721f5659b3d7585a9",
                         "installed_by": ["modules"]
                     },
                     "metaphlan/metaphlan": {
                         "branch": "master",
-                        "git_sha": "45b4cc676741a553e703bbef7d31c020fc66c6aa",
+                        "git_sha": "98ad2ea364508c5eefa3eee721f5659b3d7585a9",
                         "installed_by": ["modules"]
                     },
                     "minimap2/align": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "135d883a43b1a2324b4112cd270cf22e20835533",
                         "installed_by": ["modules"]
                     },
                     "minimap2/index": {
@@ -222,17 +222,17 @@
                     },
                     "motus/merge": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "2080397432fcb0d079121dbacf22ce42ef175cec",
                         "installed_by": ["modules"]
                     },
                     "motus/preplong": {
                         "branch": "master",
-                        "git_sha": "44a142b45f70e3fbc80d0d0e38a8c788ec17545f",
+                        "git_sha": "2080397432fcb0d079121dbacf22ce42ef175cec",
                         "installed_by": ["modules"]
                     },
                     "motus/profile": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "2080397432fcb0d079121dbacf22ce42ef175cec",
                         "installed_by": ["modules"]
                     },
                     "multiqc": {
@@ -242,32 +242,32 @@
                     },
                     "nanoq": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "nonpareil/curve": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "9707facbacc9c5c02ecf0b192f0604a29351b00a",
                         "installed_by": ["modules"]
                     },
                     "nonpareil/nonpareil": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "9707facbacc9c5c02ecf0b192f0604a29351b00a",
                         "installed_by": ["modules"]
                     },
                     "nonpareil/nonpareilcurvesr": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "9707facbacc9c5c02ecf0b192f0604a29351b00a",
                         "installed_by": ["modules"]
                     },
                     "nonpareil/set": {
                         "branch": "master",
-                        "git_sha": "41dfa3f7c0ffabb96a6a813fe321c6d1cc5b6e46",
+                        "git_sha": "9707facbacc9c5c02ecf0b192f0604a29351b00a",
                         "installed_by": ["modules"]
                     },
                     "porechop/abi": {
                         "branch": "master",
-                        "git_sha": "956a7c2d20df53c1e6acc05ca9dd5059bb9cca99",
+                        "git_sha": "6d46786420b4d7bc88eba026eb389c0c5535d120",
                         "installed_by": ["modules"]
                     },
                     "porechop/porechop": {
@@ -302,12 +302,12 @@
                     },
                     "sylph/profile": {
                         "branch": "master",
-                        "git_sha": "905850725a129463c8108efa952e5b1df62e3bb6",
+                        "git_sha": "ce985fd8f624817dcf50165cbc82dc78251675da",
                         "installed_by": ["modules"]
                     },
                     "sylphtax/merge": {
                         "branch": "master",
-                        "git_sha": "635aec1a50ccbea3a89fa1b0956457606732f0f6",
+                        "git_sha": "ce985fd8f624817dcf50165cbc82dc78251675da",
                         "installed_by": ["modules"]
                     },
                     "sylphtax/taxprof": {

--- a/modules/nf-core/bbmap/bbduk/main.nf
+++ b/modules/nf-core/bbmap/bbduk/main.nf
@@ -3,7 +3,7 @@ process BBMAP_BBDUK {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/5a/5aae5977ff9de3e01ff962dc495bfa23f4304c676446b5fdf2de5c7edfa2dc4e/data' :
         'community.wave.seqera.io/library/bbmap_pigz:07416fe99b090fa9' }"
 
@@ -14,7 +14,7 @@ process BBMAP_BBDUK {
     output:
     tuple val(meta), path('*.fastq.gz'), emit: reads
     tuple val(meta), path('*.log')     , emit: log
-    path "versions.yml"                , emit: versions
+    tuple val("${task.process}"), val('bbmap'), eval('bbversion.sh | grep -v "Duplicate cpuset"'), emit: versions_bbmap, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -34,24 +34,13 @@ process BBMAP_BBDUK {
         $args \\
         $contaminants_fa \\
         &> ${prefix}.bbduk.log
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bbmap: \$(bbversion.sh | grep -v "]")
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def output_command  = meta.single_end ? "echo '' | gzip > ${prefix}.fastq.gz" : "echo '' | gzip > ${prefix}_1.fastq.gz ; echo '' | gzip > ${prefix}_2.fastq.gz"
     """
     touch ${prefix}.bbduk.log
     $output_command
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bbmap: \$(bbversion.sh | grep -v "]")
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/bbmap/bbduk/meta.yml
+++ b/modules/nf-core/bbmap/bbduk/meta.yml
@@ -7,11 +7,12 @@ keywords:
   - fastq
 tools:
   - bbmap:
-      description: BBMap is a short read aligner, as well as various other bioinformatic
-        tools.
+      description: BBMap is a short read aligner, as well as various other
+        bioinformatic tools.
       homepage: https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/
       documentation: https://jgi.doe.gov/data-and-tools/software-tools/bbtools/bb-tools-user-guide/
-      licence: ["UC-LBL license (see package)"]
+      licence:
+        - "UC-LBL license (see package)"
       identifier: biotools:bbmap
 input:
   - - meta:
@@ -42,7 +43,7 @@ output:
           description: The trimmed/modified fastq reads
           pattern: "*fastq.gz"
           ontologies:
-            - edam: http://edamontology.org/format_3989 # GZIP format
+            - edam: http://edamontology.org/format_3989 # GZIP
   log:
     - - meta:
           type: map
@@ -54,13 +55,27 @@ output:
           description: Bbduk log file
           pattern: "*bbduk.log"
           ontologies: []
+  versions_bbmap:
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - bbmap:
+          type: string
+          description: The name of the tool
+      - bbversion.sh | grep -v "Duplicate cpuset":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - bbmap:
+          type: string
+          description: The name of the tool
+      - bbversion.sh | grep -v "Duplicate cpuset":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@MGordon09"
 maintainers:

--- a/modules/nf-core/bbmap/bbduk/tests/main.nf.test
+++ b/modules/nf-core/bbmap/bbduk/tests/main.nf.test
@@ -29,7 +29,7 @@ nextflow_process {
                 { assert process.success },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("Input is being processed as unpaired")},
                 { assert snapshot(process.out.reads,
-                                  process.out.versions).match() }
+                                  process.out.findAll { key, val -> key.startsWith('versions') }).match() }
             )
         }
 
@@ -55,7 +55,7 @@ nextflow_process {
                 { assert process.success },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("Input is being processed as paired")},
                 { assert snapshot(process.out.reads,
-                                  process.out.versions).match() }
+                                  process.out.findAll { key, val -> key.startsWith('versions') }).match() }
 
             )
         }
@@ -82,7 +82,7 @@ nextflow_process {
                 { assert process.success },
                 { assert process.out.reads.get(0).get(1).endsWith("test.trim.fastq.gz") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("Input is being processed as unpaired")},
-                { assert snapshot(process.out.versions).match() }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match() }
 
             )
         }
@@ -111,7 +111,7 @@ nextflow_process {
                 { assert process.out.reads.get(0).get(1).get(0).endsWith("test.trim_1.fastq.gz") },
                 { assert process.out.reads.get(0).get(1).get(1).endsWith("test.trim_2.fastq.gz") },
                 { assert path(process.out.log.get(0).get(1)).getText().contains("Input is being processed as paired")},
-                { assert snapshot(process.out.versions).match() }
+                { assert snapshot(process.out.findAll { key, val -> key.startsWith('versions') }).match() }
 
             )
         }

--- a/modules/nf-core/bbmap/bbduk/tests/main.nf.test.snap
+++ b/modules/nf-core/bbmap/bbduk/tests/main.nf.test.snap
@@ -13,39 +13,57 @@
                     ]
                 ]
             ],
-            [
-                "versions.yml:md5,5de3c0d4f06e53fe57a825265ebfcea9"
-            ]
+            {
+                "versions_bbmap": [
+                    [
+                        "BBMAP_BBDUK",
+                        "bbmap",
+                        "39.18"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-03-11T13:48:35.546486468",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-12T18:45:07.379143"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - single end w/ contams [fastq,fasta] - fastq": {
         "content": [
-            [
-                "versions.yml:md5,5de3c0d4f06e53fe57a825265ebfcea9"
-            ]
+            {
+                "versions_bbmap": [
+                    [
+                        "BBMAP_BBDUK",
+                        "bbmap",
+                        "39.18"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-03-11T13:48:42.244604664",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-12T18:45:12.651111"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - paired end w/ contams [fastq,fasta] - fastq": {
         "content": [
-            [
-                "versions.yml:md5,5de3c0d4f06e53fe57a825265ebfcea9"
-            ]
+            {
+                "versions_bbmap": [
+                    [
+                        "BBMAP_BBDUK",
+                        "bbmap",
+                        "39.18"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-03-11T13:48:48.784934284",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-12T18:45:17.642662"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - paired end fastq - fastq - stub": {
         "content": [
@@ -72,7 +90,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,5de3c0d4f06e53fe57a825265ebfcea9"
+                    [
+                        "BBMAP_BBDUK",
+                        "bbmap",
+                        "39.18"
+                    ]
                 ],
                 "log": [
                     [
@@ -95,16 +117,20 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,5de3c0d4f06e53fe57a825265ebfcea9"
+                "versions_bbmap": [
+                    [
+                        "BBMAP_BBDUK",
+                        "bbmap",
+                        "39.18"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-11T13:49:01.865562833",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-12T18:45:27.200074"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - single end fastq - fastq - stub": {
         "content": [
@@ -128,7 +154,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,5de3c0d4f06e53fe57a825265ebfcea9"
+                    [
+                        "BBMAP_BBDUK",
+                        "bbmap",
+                        "39.18"
+                    ]
                 ],
                 "log": [
                     [
@@ -148,16 +178,20 @@
                         "test.trim.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,5de3c0d4f06e53fe57a825265ebfcea9"
+                "versions_bbmap": [
+                    [
+                        "BBMAP_BBDUK",
+                        "bbmap",
+                        "39.18"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-11T13:48:55.283515523",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-12T18:45:22.388847"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - single end fastq - fastq": {
         "content": [
@@ -170,14 +204,20 @@
                     "test.trim.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
                 ]
             ],
-            [
-                "versions.yml:md5,5de3c0d4f06e53fe57a825265ebfcea9"
-            ]
+            {
+                "versions_bbmap": [
+                    [
+                        "BBMAP_BBDUK",
+                        "bbmap",
+                        "39.18"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-03-11T13:48:28.903217831",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-12T18:45:02.451074"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/bracken/bracken/main.nf
+++ b/modules/nf-core/bracken/bracken/main.nf
@@ -3,7 +3,7 @@ process BRACKEN_BRACKEN {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/f3/f30aa99d8d4f6ff1104f56dbacac95c1dc0905578fb250c80f145b6e80703bd1/data':
         'community.wave.seqera.io/library/bracken:3.1--22a4e66ce04c5e01' }"
 
@@ -14,7 +14,7 @@ process BRACKEN_BRACKEN {
     output:
     tuple val(meta), path(bracken_report)        , emit: reports
     tuple val(meta), path(bracken_kraken_style_report), emit: txt
-    path "versions.yml"          , emit: versions
+    tuple val("${task.process}"), val('bracken'), eval('bracken -v | cut -f2 -d"v"'), topic: versions, emit: versions_bracken
 
     when:
     task.ext.when == null || task.ext.when
@@ -31,25 +31,14 @@ process BRACKEN_BRACKEN {
         -i '${kraken_report}' \\
         -o '${bracken_report}' \\
         -w '${bracken_kraken_style_report}'
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bracken: \$(echo \$(bracken -v) | cut -f2 -d'v')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     bracken_report = "${prefix}.tsv"
     bracken_kraken_style_report = "${prefix}.kraken2.report_bracken.txt"
     """
     touch ${prefix}.tsv
     touch ${bracken_kraken_style_report}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        bracken: \$(echo \$(bracken -v) | cut -f2 -d'v')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/bracken/bracken/meta.yml
+++ b/modules/nf-core/bracken/bracken/meta.yml
@@ -60,13 +60,29 @@ output:
             Groovy Map containing sample information
             e.g. [ id:'test', single_end:false ]
           pattern: "*.txt"
+  versions_bracken:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bracken:
+          type: string
+          description: The tool name
+      - bracken -v | cut -f2 -d"v":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - bracken:
+          type: string
+          description: The tool name
+      - bracken -v | cut -f2 -d"v":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@Midnighter"
 maintainers:

--- a/modules/nf-core/bracken/bracken/tests/main.nf.test.snap
+++ b/modules/nf-core/bracken/bracken/tests/main.nf.test.snap
@@ -21,7 +21,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ],
                 "reports": [
                     [
@@ -41,16 +45,20 @@
                         "test.kraken2.report_bracken.txt:md5,ca0fbeedc4353b5fdd081688823a33df"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                "versions_bracken": [
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:17:09.050813"
+        "timestamp": "2026-01-19T14:03:31.299124251"
     },
     "sarscov2 - paired-end - fastq - genus config": {
         "content": [
@@ -74,7 +82,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ],
                 "reports": [
                     [
@@ -94,16 +106,20 @@
                         "test.kraken2.report_bracken.txt:md5,2ce58814420a3690da1f08e10e8d3a30"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                "versions_bracken": [
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:17:22.479694"
+        "timestamp": "2026-01-19T14:03:38.094543816"
     },
     "sarscov2 - paired-end - fastq": {
         "content": [
@@ -127,7 +143,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ],
                 "reports": [
                     [
@@ -147,16 +167,20 @@
                         "test.kraken2.report_bracken.txt:md5,ca0fbeedc4353b5fdd081688823a33df"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                "versions_bracken": [
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:17:35.489383"
+        "timestamp": "2026-01-19T14:03:44.706209228"
     },
     "sarscov2 - stub - fastq": {
         "content": [
@@ -178,7 +202,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ],
                 "reports": [
                     [
@@ -196,15 +224,19 @@
                         "test.kraken2.report_bracken.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e3d2c4366550ad48484aa3cae6e67ad4"
+                "versions_bracken": [
+                    [
+                        "BRACKEN_BRACKEN",
+                        "bracken",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:17:47.183592"
+        "timestamp": "2026-01-19T14:03:50.763300237"
     }
 }

--- a/modules/nf-core/bracken/combinebrackenoutputs/main.nf
+++ b/modules/nf-core/bracken/combinebrackenoutputs/main.nf
@@ -3,7 +3,7 @@ process BRACKEN_COMBINEBRACKENOUTPUTS {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/f3/f30aa99d8d4f6ff1104f56dbacac95c1dc0905578fb250c80f145b6e80703bd1/data':
         'community.wave.seqera.io/library/bracken:3.1--22a4e66ce04c5e01' }"
 
@@ -12,7 +12,7 @@ process BRACKEN_COMBINEBRACKENOUTPUTS {
 
     output:
     tuple val(meta), path("*.txt"), emit: txt
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('combine_bracken_outputs'), eval('bracken -v | cut -f2 -d"v"'), emit: versions_combine_bracken_outputs, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -20,33 +20,17 @@ process BRACKEN_COMBINEBRACKENOUTPUTS {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    // WARN: Version information not provided by tool on CLI.
-    // Please update version string below when bumping container versions.
-    def VERSION = '2.9'
+
     """
     combine_bracken_outputs.py \\
         $args \\
         --files ${input} \\
         -o ${prefix}.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        combine_bracken_output: ${VERSION}
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    // WARN: Version information not provided by tool on CLI.
-    // Please update version string below when bumping container versions.
-    def VERSION = '2.9'
     """
     touch ${prefix}.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        combine_bracken_output: ${VERSION}
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/bracken/combinebrackenoutputs/meta.yml
+++ b/modules/nf-core/bracken/combinebrackenoutputs/meta.yml
@@ -7,14 +7,15 @@ keywords:
   - reporting
 tools:
   - "bracken":
-      description: Bracken (Bayesian Reestimation of Abundance with KrakEN) is a highly
-        accurate statistical method that computes the abundance of species in DNA sequences
-        from a metagenomics sample.
+      description: Bracken (Bayesian Reestimation of Abundance with KrakEN) is a
+        highly accurate statistical method that computes the abundance of species
+        in DNA sequences from a metagenomics sample.
       homepage: https://ccb.jhu.edu/software/bracken/
       documentation: https://ccb.jhu.edu/software/bracken/index.shtml?t=manual
       tool_dev_url: https://github.com/jenniferlu717/Bracken
       doi: "10.7717/peerj-cs.104"
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: biotools:bracken
 input:
   - - meta:
@@ -39,13 +40,27 @@ output:
           description: Combined output in table format
           pattern: "*.txt"
           ontologies: []
+  versions_combine_bracken_outputs:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - combine_bracken_outputs:
+          type: string
+          description: The name of the tool
+      - bracken -v | cut -f2 -d"v":
+          type: string
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - combine_bracken_outputs:
+          type: string
+          description: The name of the tool
+      - bracken -v | cut -f2 -d"v":
+          type: string
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/bracken/combinebrackenoutputs/tests/main.nf.test.snap
+++ b/modules/nf-core/bracken/combinebrackenoutputs/tests/main.nf.test.snap
@@ -11,7 +11,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8edd746a7a248643d2cbf1b7e576fe38"
+                    [
+                        "BRACKEN_COMBINEBRACKENOUTPUTS",
+                        "combine_bracken_outputs",
+                        "3.0.1"
+                    ]
                 ],
                 "txt": [
                     [
@@ -21,16 +25,20 @@
                         "db.txt:md5,fb22ad13f9685d5bf5026542b9b2a6b8"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,8edd746a7a248643d2cbf1b7e576fe38"
+                "versions_combine_bracken_outputs": [
+                    [
+                        "BRACKEN_COMBINEBRACKENOUTPUTS",
+                        "combine_bracken_outputs",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-12T21:03:07.653082029",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.03.0"
-        },
-        "timestamp": "2024-04-16T15:11:43.6682881"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.3"
+        }
     },
     "sarscov2 - fastq - stub": {
         "content": [
@@ -44,7 +52,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,8edd746a7a248643d2cbf1b7e576fe38"
+                    [
+                        "BRACKEN_COMBINEBRACKENOUTPUTS",
+                        "combine_bracken_outputs",
+                        "3.0.1"
+                    ]
                 ],
                 "txt": [
                     [
@@ -54,15 +66,19 @@
                         "db.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,8edd746a7a248643d2cbf1b7e576fe38"
+                "versions_combine_bracken_outputs": [
+                    [
+                        "BRACKEN_COMBINEBRACKENOUTPUTS",
+                        "combine_bracken_outputs",
+                        "3.0.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-12T21:03:16.472971547",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.03.0"
-        },
-        "timestamp": "2024-04-16T15:11:50.686596"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.3"
+        }
     }
 }

--- a/modules/nf-core/cat/fastq/main.nf
+++ b/modules/nf-core/cat/fastq/main.nf
@@ -3,7 +3,7 @@ process CAT_FASTQ {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/52ccce28d2ab928ab862e25aae26314d69c8e38bd41ca9431c67ef05221348aa/data'
         : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:838ba80435a629f8'}"
 
@@ -12,23 +12,19 @@ process CAT_FASTQ {
 
     output:
     tuple val(meta), path("*.merged.fastq.gz"), emit: reads
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val("cat"), eval("cat --version 2>&1 | head -n 1 | sed 's/^.*coreutils) //; s/ .*\$//'"), emit: versions_cat, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def readList = reads instanceof List ? reads.collect { it.toString() } : [reads.toString()]
+    def readList = reads instanceof List ? reads.collect { item -> item.toString() } : [reads.toString()]
+    def compress = readList[0]?.endsWith('.gz') ? '' : '| gzip'
     if (meta.single_end) {
         if (readList.size >= 1) {
             """
-            cat ${readList.join(' ')} > ${prefix}.merged.fastq.gz
-
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
-            END_VERSIONS
+            cat ${readList.join(' ')} ${compress} > ${prefix}.merged.fastq.gz
             """
         } else {
             error("Could not find any FASTQ files to concatenate in the process input")
@@ -40,13 +36,8 @@ process CAT_FASTQ {
             def read2 = []
             readList.eachWithIndex { v, ix -> (ix & 1 ? read2 : read1) << v }
             """
-            cat ${read1.join(' ')} > ${prefix}_1.merged.fastq.gz
-            cat ${read2.join(' ')} > ${prefix}_2.merged.fastq.gz
-
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
-            END_VERSIONS
+            cat ${read1.join(' ')} ${compress} > ${prefix}_1.merged.fastq.gz
+            cat ${read2.join(' ')} ${compress} > ${prefix}_2.merged.fastq.gz
             """
         } else {
             error("Could not find any FASTQ file pairs to concatenate in the process input")
@@ -55,16 +46,11 @@ process CAT_FASTQ {
 
     stub:
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def readList = reads instanceof List ? reads.collect { it.toString() } : [reads.toString()]
+    def readList = reads instanceof List ? reads.collect { item -> item.toString() } : [reads.toString()]
     if (meta.single_end) {
         if (readList.size >= 1) {
             """
             echo '' | gzip > ${prefix}.merged.fastq.gz
-
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
-            END_VERSIONS
             """
         } else {
             error("Could not find any FASTQ files to concatenate in the process input")
@@ -75,11 +61,6 @@ process CAT_FASTQ {
             """
             echo '' | gzip > ${prefix}_1.merged.fastq.gz
             echo '' | gzip > ${prefix}_2.merged.fastq.gz
-
-            cat <<-END_VERSIONS > versions.yml
-            "${task.process}":
-                cat: \$(echo \$(cat --version 2>&1) | sed 's/^.*coreutils) //; s/ .*\$//')
-            END_VERSIONS
             """
         } else {
             error("Could not find any FASTQ file pairs to concatenate in the process input")

--- a/modules/nf-core/cat/fastq/meta.yml
+++ b/modules/nf-core/cat/fastq/meta.yml
@@ -1,9 +1,10 @@
 name: cat_fastq
-description: Concatenates fastq files
+description: Concatenates fastq files. Supports both compressed (.gz) and uncompressed inputs; uncompressed files are automatically gzip-compressed during concatenation.
 keywords:
   - cat
   - fastq
   - concatenate
+  - compress
 tools:
   - cat:
       description: |
@@ -21,6 +22,7 @@ input:
         type: file
         description: |
           List of input FastQ files to be concatenated.
+          Accepts both gzip-compressed (.fastq.gz) and uncompressed (.fastq) files.
         ontologies: []
 output:
   reads:
@@ -34,13 +36,29 @@ output:
           description: Merged fastq file
           pattern: "*.{merged.fastq.gz}"
           ontologies: []
+  versions_cat:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - cat:
+          type: string
+          description: The tool name
+      - cat --version 2>&1 | head -n 1 | sed 's/^.*coreutils) //; s/ .*\$//':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - cat:
+          type: string
+          description: The tool name
+      - cat --version 2>&1 | head -n 1 | sed 's/^.*coreutils) //; s/ .*\$//':
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/cat/fastq/tests/main.nf.test
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test
@@ -7,6 +7,7 @@ nextflow_process {
     tag "modules_nfcore"
     tag "cat"
     tag "cat/fastq"
+    tag "gunzip"
 
     test("test_cat_fastq_single_end") {
 
@@ -88,6 +89,76 @@ nextflow_process {
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
                     file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
                 ])
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_cat_fastq_single_end_uncompressed") {
+
+        setup {
+            run("GUNZIP") {
+                script "../../../gunzip/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of(
+                        [[ id:'r1' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)],
+                        [[ id:'r2' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
+                    )
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = GUNZIP.out.gunzip
+                    .toSortedList { a, b -> a[0].id <=> b[0].id }
+                    .map { items -> [[ id: 'test', single_end: true ], items.collect { it[1] }] }
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+    }
+
+    test("test_cat_fastq_paired_end_uncompressed") {
+
+        setup {
+            run("GUNZIP") {
+                script "../../../gunzip/main.nf"
+                process {
+                    """
+                    input[0] = Channel.of(
+                        [[ id:'a' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)],
+                        [[ id:'b' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)],
+                        [[ id:'c' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_1.fastq.gz', checkIfExists: true)],
+                        [[ id:'d' ], file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test2_2.fastq.gz', checkIfExists: true)]
+                    )
+                    """
+                }
+            }
+        }
+
+        when {
+            process {
+                """
+                input[0] = GUNZIP.out.gunzip
+                    .toSortedList { a, b -> a[0].id <=> b[0].id }
+                    .map { items -> [[ id: 'test', single_end: false ], items.collect { it[1] }] }
                 """
             }
         }

--- a/modules/nf-core/cat/fastq/tests/main.nf.test.snap
+++ b/modules/nf-core/cat/fastq/tests/main.nf.test.snap
@@ -22,7 +22,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -33,16 +37,20 @@
                         "test.merged.fastq.gz:md5,4161df271f9bfcd25d5845a1e220dbec"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:24:04.902821069"
+        "timestamp": "2025-12-10T14:31:42.84401526"
     },
     "test_cat_fastq_paired_end_same_name": {
         "content": [
@@ -60,7 +68,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -74,16 +86,20 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:23:57.476357974"
+        "timestamp": "2025-12-10T14:31:36.820489323"
     },
     "test_cat_fastq_paired_end_same_name - stub": {
         "content": [
@@ -101,7 +117,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -115,16 +135,112 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:24:34.615815265"
+        "timestamp": "2025-12-10T14:32:06.262192935"
+    },
+    "test_cat_fastq_single_end_uncompressed": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.merged.fastq.gz:md5,ee314a9bd568d06617171b0c85f508da"
+                    ]
+                ],
+                "1": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.merged.fastq.gz:md5,ee314a9bd568d06617171b0c85f508da"
+                    ]
+                ],
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-02-09T10:03:24.344628"
+    },
+    "test_cat_fastq_paired_end_uncompressed": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
+                            "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
+                        ]
+                    ]
+                ],
+                "1": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
+                ],
+                "reads": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        [
+                            "test_1.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22",
+                            "test_2.merged.fastq.gz:md5,a52cab0b840c7178b0ea83df1fdbe8d5"
+                        ]
+                    ]
+                ],
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-02-09T10:03:37.568053"
     },
     "test_cat_fastq_single_end": {
         "content": [
@@ -139,7 +255,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -150,16 +270,20 @@
                         "test.merged.fastq.gz:md5,ee314a9bd568d06617171b0c85f508da"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:23:32.489874386"
+        "timestamp": "2025-12-10T14:31:18.859169785"
     },
     "test_cat_fastq_single_end_same_name": {
         "content": [
@@ -174,7 +298,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -185,16 +313,20 @@
                         "test.merged.fastq.gz:md5,3ad9406595fafec8172368f9cd0b6a22"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:23:49.184759506"
+        "timestamp": "2025-12-10T14:31:30.942615287"
     },
     "test_cat_fastq_single_end - stub": {
         "content": [
@@ -209,7 +341,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -220,16 +356,20 @@
                         "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:24:12.857293744"
+        "timestamp": "2025-12-10T14:31:48.827990633"
     },
     "test_cat_fastq_paired_end_no_files": {
         "content": [
@@ -264,7 +404,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -275,16 +419,20 @@
                         "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:24:27.816080065"
+        "timestamp": "2025-12-10T14:32:00.586584379"
     },
     "test_cat_fastq_paired_end": {
         "content": [
@@ -302,7 +450,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -316,16 +468,20 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:23:41.739469187"
+        "timestamp": "2025-12-10T14:31:25.159365603"
     },
     "test_cat_fastq_single_end_no_files": {
         "content": [
@@ -353,7 +509,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -367,16 +527,20 @@
                         ]
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:24:21.178950408"
+        "timestamp": "2025-12-10T14:31:54.850702874"
     },
     "test_cat_fastq_single_end_single_file - stub": {
         "content": [
@@ -391,7 +555,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ],
                 "reads": [
                     [
@@ -402,15 +570,19 @@
                         "test.merged.fastq.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6ef4fd28546a005865b9454bbedbf81a"
+                "versions_cat": [
+                    [
+                        "CAT_FASTQ",
+                        "cat",
+                        "9.5"
+                    ]
                 ]
             }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-02-25T17:24:40.851404993"
+        "timestamp": "2025-12-10T14:32:11.746498148"
     }
 }

--- a/modules/nf-core/ganon/classify/main.nf
+++ b/modules/nf-core/ganon/classify/main.nf
@@ -2,9 +2,9 @@ process GANON_CLASSIFY {
     tag "${meta.id}"
     label 'process_high'
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/ganon:2.1.0--py310hab1bfa5_1'
-        : 'biocontainers/ganon:2.1.0--py310hab1bfa5_1'}"
+        : 'quay.io/biocontainers/ganon:2.1.0--py310hab1bfa5_1'}"
 
     input:
     tuple val(meta), path(fastqs)
@@ -17,7 +17,7 @@ process GANON_CLASSIFY {
     tuple val(meta), path("*.all"), emit: all, optional: true
     tuple val(meta), path("*.unc"), emit: unc, optional: true
     tuple val(meta), path("*.log"), emit: log
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('ganon'), eval("ganon --version 2>1 | sed 's/.*ganon //g'"), emit: versions_ganon, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -38,16 +38,10 @@ process GANON_CLASSIFY {
         ${input} \
         2>&1 | tee ${prefix}.log
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ganon: \$(echo \$(ganon --version 2>1) | sed 's/.*ganon //g')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input = meta.single_end ? "--single-reads ${fastqs}" : "--paired-reads ${fastqs}"
     """
     touch ${prefix}.tre
     touch ${prefix}.rep
@@ -56,9 +50,5 @@ process GANON_CLASSIFY {
     touch ${prefix}.unc
     touch ${prefix}.log
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ganon: \$(echo \$(ganon --version 2>1) | sed 's/.*ganon //g')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/ganon/classify/meta.yml
+++ b/modules/nf-core/ganon/classify/meta.yml
@@ -16,7 +16,8 @@ tools:
       documentation: "https://github.com/pirovc/ganon"
       tool_dev_url: "https://github.com/pirovc/ganon"
       doi: "10.1093/bioinformatics/btaa458"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:ganon
 input:
   - - meta:
@@ -66,8 +67,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.one":
           type: file
-          description: Information about a single (best) match of a given read after
-            EM or LCA algorithms
+          description: Information about a single (best) match of a given read
+            after EM or LCA algorithms
           pattern: "*.one"
           ontologies: []
   all:
@@ -103,13 +104,27 @@ output:
           description: Text file containing console output from ganon classify
           pattern: "*.log"
           ontologies: []
+  versions_ganon:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ganon:
+          type: string
+          description: The name of the tool
+      - ganon --version 2>1 | sed 's/.*ganon //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ganon:
+          type: string
+          description: The name of the tool
+      - ganon --version 2>1 | sed 's/.*ganon //g':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/ganon/classify/tests/main.nf.test
+++ b/modules/nf-core/ganon/classify/tests/main.nf.test
@@ -17,9 +17,9 @@ nextflow_process {
                 process {
                     """
                     input[0] = [
-                                [ id:'test' ], // meta map
-                                file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true),
-                            ]
+                        [ id:'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
+                    ]
                     input[1] = []
                     input[2] = []
                     input[3] = []
@@ -34,10 +34,8 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:true ], // meta map
-                    [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                    ]
+                    [ id:'test', single_end:true ],
+                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true) ]
                 ]
                 input[1] = GANON_BUILDCUSTOM.out.db.map{it[1]}
                 """
@@ -50,7 +48,7 @@ nextflow_process {
                 { assert snapshot(
                     process.out.tre,
                     process.out.report,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith('versions') }
                 ).match()},
                 { assert file(process.out.log[0][1]).text.contains("Total elapsed time:") }
             )
@@ -64,10 +62,10 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test', single_end:false ],
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
-                        file(params.test_data['sarscov2']['illumina']['test_2_fastq_gz'], checkIfExists: true)
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = GANON_BUILDCUSTOM.out.db.map{it[1]}
@@ -81,7 +79,7 @@ nextflow_process {
                 { assert snapshot(
                         process.out.tre,
                         process.out.report,
-                        process.out.versions
+                        process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 },
                 { assert file(process.out.log[0][1]).text.contains("Total elapsed time:") }
@@ -98,9 +96,9 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:true ], // meta map
+                    [ id:'test', single_end:true ],
                     [
-                        file(params.test_data['sarscov2']['illumina']['test_1_fastq_gz'], checkIfExists: true),
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                     ]
                 ]
                 input[1] = []

--- a/modules/nf-core/ganon/classify/tests/main.nf.test.snap
+++ b/modules/nf-core/ganon/classify/tests/main.nf.test.snap
@@ -57,7 +57,11 @@
                     ]
                 ],
                 "6": [
-                    "versions.yml:md5,7c113ab3c2c1ea32c9f27ceef48db17a"
+                    [
+                        "GANON_CLASSIFY",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ],
                 "all": [
                     [
@@ -113,16 +117,20 @@
                         "test.unc:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7c113ab3c2c1ea32c9f27ceef48db17a"
+                "versions_ganon": [
+                    [
+                        "GANON_CLASSIFY",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-13T15:27:38.992810123",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-07T17:06:22.835846753"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 paired-end [fastq]": {
         "content": [
@@ -132,7 +140,7 @@
                         "id": "test",
                         "single_end": false
                     },
-                    "test.tre:md5,66c0b9ed247989682fe3bae842d37a76"
+                    "test.tre:md5,2eebb02e0e37268314d41cc274ec3aa0"
                 ]
             ],
             [
@@ -144,15 +152,21 @@
                     "test.rep:md5,757e5cbf7a978913277401285d743336"
                 ]
             ],
-            [
-                "versions.yml:md5,7c113ab3c2c1ea32c9f27ceef48db17a"
-            ]
+            {
+                "versions_ganon": [
+                    [
+                        "GANON_CLASSIFY",
+                        "ganon",
+                        "2.1.0"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-03-13T15:27:29.233281072",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-07T19:26:16.339673954"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 single-end [fastq]": {
         "content": [
@@ -162,7 +176,7 @@
                         "id": "test",
                         "single_end": true
                     },
-                    "test.tre:md5,3d2ef6fe0571d7aa7324539407a59630"
+                    "test.tre:md5,828f3ea0e15ae28d95f71ae4874edc38"
                 ]
             ],
             [
@@ -174,14 +188,20 @@
                     "test.rep:md5,9b5f8051aa459a80a678e36259a15746"
                 ]
             ],
-            [
-                "versions.yml:md5,7c113ab3c2c1ea32c9f27ceef48db17a"
-            ]
+            {
+                "versions_ganon": [
+                    [
+                        "GANON_CLASSIFY",
+                        "ganon",
+                        "2.1.0"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-03-13T15:26:59.020360952",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-07T19:25:41.074523387"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/ganon/report/main.nf
+++ b/modules/nf-core/ganon/report/main.nf
@@ -2,9 +2,9 @@ process GANON_REPORT {
     tag "${meta.id}"
     label 'process_single'
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/ganon:2.1.0--py310hab1bfa5_1'
-        : 'biocontainers/ganon:2.1.0--py310hab1bfa5_1'}"
+        : 'quay.io/biocontainers/ganon:2.1.0--py310hab1bfa5_1'}"
 
     input:
     tuple val(meta), path(rep)
@@ -12,7 +12,7 @@ process GANON_REPORT {
 
     output:
     tuple val(meta), path("*.tre"), emit: tre
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('ganon'), eval("ganon --version 2>1 | sed 's/.*ganon //g'"), emit: versions_ganon, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -31,22 +31,13 @@ process GANON_REPORT {
         --db-prefix \${dbprefix%%.*ibf} \\
         ${args}
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ganon: \$(echo \$(ganon --version 2>1) | sed 's/.*ganon //g')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
     touch ${prefix}.tre
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ganon: \$(echo \$(ganon --version 2>1) | sed 's/.*ganon //g')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/ganon/report/meta.yml
+++ b/modules/nf-core/ganon/report/meta.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: "ganon_report"
 description: Generate a ganon report file from the output of ganon classify
 keywords:
@@ -17,7 +16,8 @@ tools:
       documentation: "https://github.com/pirovc/ganon"
       tool_dev_url: "https://github.com/pirovc/ganon"
       doi: "10.1093/bioinformatics/btaa458"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:ganon
 input:
   - - meta:
@@ -44,17 +44,31 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.tre":
           type: file
-          description: Output ganon report containing taxonomic profile information.
-            Formatting of contents depends on --output-format.
+          description: Output ganon report containing taxonomic profile
+            information. Formatting of contents depends on --output-format.
           pattern: "*.tre"
           ontologies: []
+  versions_ganon:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ganon:
+          type: string
+          description: The name of the tool
+      - ganon --version 2>1 | sed 's/.*ganon //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ganon:
+          type: string
+          description: The name of the tool
+      - ganon --version 2>1 | sed 's/.*ganon //g':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/ganon/report/tests/main.nf.test.snap
+++ b/modules/nf-core/ganon/report/tests/main.nf.test.snap
@@ -12,7 +12,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,e405868d6136de433a8ddbd8e6e3333d"
+                    [
+                        "GANON_REPORT",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ],
                 "tre": [
                     [
@@ -23,16 +27,20 @@
                         "test.tre:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e405868d6136de433a8ddbd8e6e3333d"
+                "versions_ganon": [
+                    [
+                        "GANON_REPORT",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-13T15:28:25.546602839",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-07T17:09:42.438141974"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 single-end [fastq]": {
         "content": [
@@ -43,11 +51,15 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.tre:md5,3d2ef6fe0571d7aa7324539407a59630"
+                        "test.tre:md5,828f3ea0e15ae28d95f71ae4874edc38"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,e405868d6136de433a8ddbd8e6e3333d"
+                    [
+                        "GANON_REPORT",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ],
                 "tre": [
                     [
@@ -55,18 +67,22 @@
                             "id": "test",
                             "single_end": true
                         },
-                        "test.tre:md5,3d2ef6fe0571d7aa7324539407a59630"
+                        "test.tre:md5,828f3ea0e15ae28d95f71ae4874edc38"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e405868d6136de433a8ddbd8e6e3333d"
+                "versions_ganon": [
+                    [
+                        "GANON_REPORT",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-13T15:28:11.822291605",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-07T18:32:50.997968794"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/ganon/table/main.nf
+++ b/modules/nf-core/ganon/table/main.nf
@@ -2,16 +2,16 @@ process GANON_TABLE {
     tag "${meta.id}"
     label 'process_single'
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/ganon:2.1.0--py310hab1bfa5_1'
-        : 'biocontainers/ganon:2.1.0--py310hab1bfa5_1'}"
+        : 'quay.io/biocontainers/ganon:2.1.0--py310hab1bfa5_1'}"
 
     input:
     tuple val(meta), path(tre)
 
     output:
     tuple val(meta), path("*.txt"), emit: txt
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('ganon'), eval("ganon --version 2>1 | sed 's/.*ganon //g'"), emit: versions_ganon, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -26,22 +26,13 @@ process GANON_TABLE {
         --output-file ${prefix}.txt \\
         ${args}
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ganon: \$(echo \$(ganon --version 2>1) | sed 's/.*ganon //g')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
 
     """
     touch ${prefix}.txt
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        ganon: \$(echo \$(ganon --version 2>1) | sed 's/.*ganon //g')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/ganon/table/meta.yml
+++ b/modules/nf-core/ganon/table/meta.yml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: "ganon_table"
-description: Generate a multi-sample report file from the output of ganon report runs
+description: Generate a multi-sample report file from the output of ganon report
+  runs
 keywords:
   - ganon
   - metagenomics
@@ -18,7 +18,8 @@ tools:
       documentation: "https://github.com/pirovc/ganon"
       tool_dev_url: "https://github.com/pirovc/ganon"
       doi: "10.1093/bioinformatics/btaa458"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:ganon
 input:
   - - meta:
@@ -40,17 +41,32 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.txt":
           type: file
-          description: Output ganon table containing taxonomic profile information of
-            multiple samples. Formatting of contents depends on --output-format.
+          description: Output ganon table containing taxonomic profile information
+            of multiple samples. Formatting of contents depends on
+            --output-format.
           pattern: "*.txt"
           ontologies: []
+  versions_ganon:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ganon:
+          type: string
+          description: The name of the tool
+      - ganon --version 2>1 | sed 's/.*ganon //g':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - ganon:
+          type: string
+          description: The name of the tool
+      - ganon --version 2>1 | sed 's/.*ganon //g':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/ganon/table/tests/main.nf.test.snap
+++ b/modules/nf-core/ganon/table/tests/main.nf.test.snap
@@ -11,7 +11,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6a8b6c7a69b2bdd5490414f3352b5a7d"
+                    [
+                        "GANON_TABLE",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ],
                 "txt": [
                     [
@@ -21,16 +25,20 @@
                         "db1.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6a8b6c7a69b2bdd5490414f3352b5a7d"
+                "versions_ganon": [
+                    [
+                        "GANON_TABLE",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-13T15:29:17.418763207",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-07T17:13:04.938896022"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 single-end [fastq]": {
         "content": [
@@ -40,29 +48,37 @@
                         {
                             "id": "db1"
                         },
-                        "db1.txt:md5,c2f38e9f47f8701d8f37a59dffed88a3"
+                        "db1.txt:md5,1da6f44d95981cca78a50b32d19f2337"
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,6a8b6c7a69b2bdd5490414f3352b5a7d"
+                    [
+                        "GANON_TABLE",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ],
                 "txt": [
                     [
                         {
                             "id": "db1"
                         },
-                        "db1.txt:md5,c2f38e9f47f8701d8f37a59dffed88a3"
+                        "db1.txt:md5,1da6f44d95981cca78a50b32d19f2337"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,6a8b6c7a69b2bdd5490414f3352b5a7d"
+                "versions_ganon": [
+                    [
+                        "GANON_TABLE",
+                        "ganon",
+                        "2.1.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-13T15:29:01.332534071",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-10-07T18:33:41.271256635"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/gunzip/main.nf
+++ b/modules/nf-core/gunzip/main.nf
@@ -3,7 +3,7 @@ process GUNZIP {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/52/52ccce28d2ab928ab862e25aae26314d69c8e38bd41ca9431c67ef05221348aa/data'
         : 'community.wave.seqera.io/library/coreutils_grep_gzip_lbzip2_pruned:838ba80435a629f8'}"
 
@@ -12,15 +12,16 @@ process GUNZIP {
 
     output:
     tuple val(meta), path("${gunzip}"), emit: gunzip
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('gunzip'), eval('gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//"'), topic: versions, emit: versions_gunzip
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
     def args = task.ext.args ?: ''
-    def extension = (archive.toString() - '.gz').tokenize('.')[-1]
-    def name = archive.toString() - '.gz' - ".${extension}"
+    def nameWithoutGz = archive.extension == 'gz' ? archive.baseName : archive.name
+	def extension = file(nameWithoutGz).extension
+	def name = file(nameWithoutGz).baseName
     def prefix = task.ext.prefix ?: name
     gunzip = prefix + ".${extension}"
     """
@@ -32,24 +33,15 @@ process GUNZIP {
         ${args} \\
         ${archive} \\
         > ${gunzip}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
-    def extension = (archive.toString() - '.gz').tokenize('.')[-1]
-    def name = archive.toString() - '.gz' - ".${extension}"
+    def nameWithoutGz = archive.extension == 'gz' ? archive.baseName : archive.name
+	def extension = file(nameWithoutGz).extension
+	def name = file(nameWithoutGz).baseName
     def prefix = task.ext.prefix ?: name
     gunzip = prefix + ".${extension}"
     """
     touch ${gunzip}
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        gunzip: \$(echo \$(gunzip --version 2>&1) | sed 's/^.*(gzip) //; s/ Copyright.*\$//')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/gunzip/meta.yml
+++ b/modules/nf-core/gunzip/meta.yml
@@ -34,13 +34,29 @@ output:
           description: Compressed/uncompressed file
           pattern: "*.*"
           ontologies: []
+  versions_gunzip:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gunzip:
+          type: string
+          description: The tool name
+      - gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - gunzip:
+          type: string
+          description: The tool name
+      - gunzip --version 2>&1 | head -1 | sed "s/^.*(gzip) //; s/ Copyright.*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/gunzip/tests/main.nf.test
+++ b/modules/nf-core/gunzip/tests/main.nf.test
@@ -89,6 +89,60 @@ nextflow_process {
 
     }
 
+    test("Should decompress file with extension appearing multiple times in filename") {
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                        [],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true).copyTo('test.fa.v1.fa.gz')
+                    ]
+                )
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert file(process.out.gunzip[0][1]).name == 'test.fa.v1.fa' }
+            )
+        }
+
+    }
+
+    test("Should decompress file with extension appearing multiple times in filename - prefix") {
+
+        config './nextflow.config'
+
+        when {
+            params {
+                outdir = "$outputDir"
+            }
+            process {
+                """
+                input[0] = Channel.of([
+                        [ id: 'test' ],
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true).copyTo('test.fa.v1.fa.gz')
+                    ]
+                )
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
     test("Should run without failures - prefix - stub") {
 
         options '-stub'

--- a/modules/nf-core/gunzip/tests/main.nf.test.snap
+++ b/modules/nf-core/gunzip/tests/main.nf.test.snap
@@ -1,4 +1,45 @@
 {
+    "Should decompress file with extension appearing multiple times in filename - prefix": {
+        "content": [
+            {
+                "0": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.xyz.fa:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "1": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
+                ],
+                "gunzip": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.xyz.fa:md5,4161df271f9bfcd25d5845a1e220dbec"
+                    ]
+                ],
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-04-15T15:20:52.59447",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "25.10.4"
+        }
+    },
     "Should run without failures - prefix - stub": {
         "content": [
             {
@@ -11,7 +52,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ],
                 "gunzip": [
                     [
@@ -21,16 +66,20 @@
                         "test.xyz.fastq:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-01-19T17:21:56.633550769",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
-        },
-        "timestamp": "2024-12-13T11:48:22.080222697"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        }
     },
     "Should run without failures - stub": {
         "content": [
@@ -44,7 +93,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ],
                 "gunzip": [
                     [
@@ -54,16 +107,20 @@
                         "test_1.fastq:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-01-19T17:21:51.435621199",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
-        },
-        "timestamp": "2024-12-13T11:48:14.593020264"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        }
     },
     "Should run without failures": {
         "content": [
@@ -77,7 +134,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ],
                 "gunzip": [
                     [
@@ -87,16 +148,20 @@
                         "test_1.fastq:md5,4161df271f9bfcd25d5845a1e220dbec"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-01-19T17:21:40.613975821",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
-        },
-        "timestamp": "2024-12-13T11:48:01.295397925"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        }
     },
     "Should run without failures - prefix": {
         "content": [
@@ -110,7 +175,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ],
                 "gunzip": [
                     [
@@ -120,15 +189,19 @@
                         "test.xyz.fastq:md5,4161df271f9bfcd25d5845a1e220dbec"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,d327e4a19a6d5c5e974136cef8999d8c"
+                "versions_gunzip": [
+                    [
+                        "GUNZIP",
+                        "gunzip",
+                        "1.13"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-01-19T17:21:46.086880414",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
-        },
-        "timestamp": "2024-12-13T11:48:07.414271387"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        }
     }
 }

--- a/modules/nf-core/kaiju/kaiju/main.nf
+++ b/modules/nf-core/kaiju/kaiju/main.nf
@@ -1,19 +1,19 @@
 process KAIJU_KAIJU {
-    tag "${meta.id}"
+    tag "$meta.id"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
-        ? 'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0'
-        : 'quay.io/biocontainers/kaiju:1.10.0--h43eeafb_0'}"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0':
+        'biocontainers/kaiju:1.10.0--h43eeafb_0' }"
 
     input:
     tuple val(meta), path(reads)
-    path db
+    path(db)
 
     output:
     tuple val(meta), path('*.tsv'), emit: results
-    tuple val("${task.process}"), val('kaiju'), eval("kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //'"), emit: versions_kaiju, topic: versions
+    path "versions.yml"           , emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,27 +22,34 @@ process KAIJU_KAIJU {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def input = meta.single_end ? "-i ${reads}" : "-i ${reads[0]} -j ${reads[1]}"
-
-    def db_list = db instanceof List ? db : db.listDirectory()
-
-    if (!db_list.find { db_files -> db_files.name.endsWith('names.dmp') } || !db_list.find { db_files -> db_files.name.endsWith('nodes.dmp') }) {
-        error('[KAIJU_KAIJU] Module error: Missing one of `nodes.dmp`, `names.dmp`. Check input.')
-    }
     """
     dbnodes=`find -L ${db} -name "*nodes.dmp"`
     dbname=`find -L ${db} -name "*.fmi" -not -name "._*"`
     kaiju \\
-        ${args} \\
-        -z ${task.cpus} \\
+        $args \\
+        -z $task.cpus \\
         -t \$dbnodes \\
         -f \$dbname \\
         -o ${prefix}.tsv \\
-        ${input}
+        $input
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
+    END_VERSIONS
     """
 
     stub:
+    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
+    def input = meta.single_end ? "-i ${reads}" : "-i ${reads[0]} -j ${reads[1]}"
     """
     touch ${prefix}.tsv
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
+    END_VERSIONS
     """
+
 }

--- a/modules/nf-core/kaiju/kaiju/main.nf
+++ b/modules/nf-core/kaiju/kaiju/main.nf
@@ -1,19 +1,19 @@
 process KAIJU_KAIJU {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0':
-        'biocontainers/kaiju:1.10.0--h43eeafb_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0'
+        : 'quay.io/biocontainers/kaiju:1.10.0--h43eeafb_0'}"
 
     input:
     tuple val(meta), path(reads)
-    path(db)
+    path db
 
     output:
     tuple val(meta), path('*.tsv'), emit: results
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('kaiju'), eval("kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //'"), emit: versions_kaiju, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,34 +22,27 @@ process KAIJU_KAIJU {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     def input = meta.single_end ? "-i ${reads}" : "-i ${reads[0]} -j ${reads[1]}"
+
+    def db_list = db instanceof List ? db : db.listDirectory()
+
+    if (!db_list.find { db_files -> db_files.name.endsWith('names.dmp') } || !db_list.find { db_files -> db_files.name.endsWith('nodes.dmp') }) {
+        error('[KAIJU_KAIJU] Module error: Missing one of `nodes.dmp`, `names.dmp`. Check input.')
+    }
     """
     dbnodes=`find -L ${db} -name "*nodes.dmp"`
     dbname=`find -L ${db} -name "*.fmi" -not -name "._*"`
     kaiju \\
-        $args \\
-        -z $task.cpus \\
+        ${args} \\
+        -z ${task.cpus} \\
         -t \$dbnodes \\
         -f \$dbname \\
         -o ${prefix}.tsv \\
-        $input
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
-    END_VERSIONS
+        ${input}
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input = meta.single_end ? "-i ${reads}" : "-i ${reads[0]} -j ${reads[1]}"
     """
     touch ${prefix}.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
-    END_VERSIONS
     """
-
 }

--- a/modules/nf-core/kaiju/kaiju/meta.yml
+++ b/modules/nf-core/kaiju/kaiju/meta.yml
@@ -13,7 +13,8 @@ tools:
       documentation: https://github.com/bioinformatics-centre/kaiju/blob/master/README.md
       tool_dev_url: https://github.com/bioinformatics-centre/kaiju
       doi: "10.1038/ncomms11257"
-      licence: ["GNU GPL v3"]
+      licence:
+        - "GNU GPL v3"
       identifier: biotools:kaiju
 input:
   - - meta:
@@ -28,12 +29,12 @@ input:
           respectively.
         pattern: "*.{fastq,fq,fasta,fa,fsa,fas,fna,fastq.gz,fq.gz,fasta.gz,fa.gz,fsa.gz,fas.gz,fna.gz}"
         ontologies:
-          - edam: http://edamontology.org/format_1930 # FASTQ
+          - edam: http://edamontology.org/format_1930
   - db:
       type: directory
       description: |
-        List containing the database and nodes files for Kaiju
-        e.g. [ 'database.fmi', 'nodes.dmp' ]
+        List or directory containing the database and NCBI taxonomy files (names and nodes) for Kaiju
+        e.g. [ 'database.fmi', 'names.dmp', 'nodes.dmp' ]
 output:
   results:
     - - meta:
@@ -46,14 +47,28 @@ output:
           description: Results with taxonomic classification of each read
           pattern: "*.tsv"
           ontologies:
-            - edam: http://edamontology.org/format_3475 # TSV
+            - edam: http://edamontology.org/format_3475
+  versions_kaiju:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - kaiju:
+          type: string
+          description: The name of the tool
+      - kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - kaiju:
+          type: string
+          description: The name of the tool
+      - kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@talnor"
   - "@sofstam"

--- a/modules/nf-core/kaiju/kaiju/tests/main.nf.test
+++ b/modules/nf-core/kaiju/kaiju/tests/main.nf.test
@@ -10,18 +10,19 @@ nextflow_process {
     tag "kaiju/kaiju"
     tag "untar"
 
-    test("sarscov2 - fastq - single-end") {
 
-        setup {
-            run ("UNTAR"){
-                script "../../../untar/main.nf"
-                process {
-                    """
-                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
-                    """
-                }
+    setup {
+        run ("UNTAR"){
+            script "../../../untar/main.nf"
+            process {
+                """
+                input[0] = [ [id: 'db'], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
+                """
             }
         }
+    }
+
+    test("sarscov2 - fastq - single-end") {
 
         when {
             process {
@@ -30,7 +31,18 @@ nextflow_process {
                         [ id:'test', single_end:true ], // meta map
                         file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                         ]
-                input[1] = UNTAR.out.untar.map{ it[1] }
+
+                input[1] = UNTAR.out.untar
+                    .map {
+                        meta, untar ->
+                            def db = [
+                                untar,
+                                file(params.modules_testdata_base_path + "delete_me/kaiju/nodes.dmp", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "delete_me/kaiju/names.dmp", checkIfExists: true)
+                            ]
+                        [meta, db ]
+                    }
+                    .map{ it[1] }
                 """
             }
         }
@@ -38,7 +50,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert path(process.out.results[0][1]).getText().contains("C\tERR5069949.2257580\t2697049") }
+                { assert path(process.out.results[0][1]).getText().contains("C\tERR5069949.2257580\t2697049") },
+                { assert snapshot(
+                    file(process.out.results[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
 
@@ -46,26 +62,25 @@ nextflow_process {
 
     test("sarscov2 - fastq - paired-end") {
 
-        setup {
-            run ("UNTAR"){
-                script "../../../untar/main.nf"
-                process {
-                    """
-                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
-                    """
-                }
-            }
-        }
-
         when {
             process {
                 """
-                input[0] = [
-                    [ id:'test', single_end:false ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
-                ]
-                input[1] = UNTAR.out.untar.map{ it[1] }
+                input[0] =  [
+                        [ id:'test', single_end:true ], // meta map
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                        ]
+
+                input[1] = UNTAR.out.untar
+                    .map {
+                        meta, untar ->
+                            def db = [
+                                untar,
+                                file(params.modules_testdata_base_path + "delete_me/kaiju/nodes.dmp", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "delete_me/kaiju/names.dmp", checkIfExists: true)
+                            ]
+                        [meta, db ]
+                    }
+                    .map{ it[1] }
                 """
             }
         }
@@ -73,7 +88,11 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert path(process.out.results[0][1]).getText().contains("C\tERR5069949.2257580\t2697049") }
+                { assert path(process.out.results[0][1]).getText().contains("C\tERR5069949.2257580\t2697049") },
+                { assert snapshot(
+                    file(process.out.results[0][1]).name,
+                    process.out.findAll { key, val -> key.startsWith('versions') }
+                ).match() }
             )
         }
     }
@@ -82,26 +101,25 @@ nextflow_process {
 
         options '-stub'
 
-        setup {
-            run ("UNTAR"){
-                script "../../../untar/main.nf"
-                process {
-                    """
-                    input[0] = [ [], file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kaiju.tar.gz', checkIfExists: true) ]
-                    """
-                }
-            }
-        }
-
         when {
             process {
                 """
-                input[0] = [
-                    [ id:'test', single_end:false ],
-                    [ file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true),
-                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz', checkIfExists: true)]
-                ]
-                input[1] = UNTAR.out.untar.map{ it[1] }
+                input[0] =  [
+                        [ id:'test', single_end:true ], // meta map
+                        file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                        ]
+
+                input[1] = UNTAR.out.untar
+                    .map {
+                        meta, untar ->
+                            def db = [
+                                untar,
+                                file(params.modules_testdata_base_path + "delete_me/kaiju/nodes.dmp", checkIfExists: true),
+                                file(params.modules_testdata_base_path + "delete_me/kaiju/names.dmp", checkIfExists: true)
+                            ]
+                        [meta, db ]
+                    }
+                    .map{ it[1] }
                 """
             }
         }
@@ -109,7 +127,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(file(process.out.results[0][1]).name).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/kaiju/kaiju/tests/main.nf.test.snap
+++ b/modules/nf-core/kaiju/kaiju/tests/main.nf.test.snap
@@ -1,8 +1,67 @@
 {
     "sarscov2 - fastq - stub": {
         "content": [
-            "test.tsv"
+            {
+                "results": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": true
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_kaiju": [
+                    [
+                        "KAIJU_KAIJU",
+                        "kaiju",
+                        "1.10.0"
+                    ]
+                ]
+            }
         ],
-        "timestamp": "2024-01-20T14:44:57.116024519"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-15T14:22:59.612319412"
+    },
+    "sarscov2 - fastq - paired-end": {
+        "content": [
+            "test.tsv",
+            {
+                "versions_kaiju": [
+                    [
+                        "KAIJU_KAIJU",
+                        "kaiju",
+                        "1.10.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-15T14:34:07.640079926"
+    },
+    "sarscov2 - fastq - single-end": {
+        "content": [
+            "test.tsv",
+            {
+                "versions_kaiju": [
+                    [
+                        "KAIJU_KAIJU",
+                        "kaiju",
+                        "1.10.0"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-15T14:33:59.077645447"
     }
 }

--- a/modules/nf-core/kaiju/kaiju2krona/main.nf
+++ b/modules/nf-core/kaiju/kaiju2krona/main.nf
@@ -1,19 +1,19 @@
 process KAIJU_KAIJU2KRONA {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0':
-        'biocontainers/kaiju:1.10.0--h43eeafb_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0'
+        : 'quay.io/biocontainers/kaiju:1.10.0--h43eeafb_0'}"
 
     input:
     tuple val(meta), path(tsv)
-    path(db)
+    path db
 
     output:
     tuple val(meta), path("*.txt"), emit: txt
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('kaiju'), eval("kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //'"), emit: versions_kaiju, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -25,27 +25,16 @@ process KAIJU_KAIJU2KRONA {
     dbnodes=`find -L ${db} -name "*nodes.dmp"`
     dbnames=`find -L ${db} -name "*names.dmp"`
     kaiju2krona \\
-        $args \\
+        ${args} \\
         -t \$dbnodes \\
         -n \$dbnames \\
         -i ${tsv} \\
         -o ${prefix}.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/kaiju/kaiju2krona/meta.yml
+++ b/modules/nf-core/kaiju/kaiju2krona/meta.yml
@@ -13,7 +13,8 @@ tools:
       documentation: https://github.com/bioinformatics-centre/kaiju/blob/master/README.md
       tool_dev_url: https://github.com/bioinformatics-centre/kaiju
       doi: "10.1038/ncomms11257"
-      licence: ["GNU GPL v3"]
+      licence:
+        - "GNU GPL v3"
       identifier: biotools:kaiju
 input:
   - - meta:
@@ -26,7 +27,7 @@ input:
         description: Kaiju tab-separated output file
         pattern: "*.{tsv,txt}"
         ontologies:
-          - edam: http://edamontology.org/format_3475 # TSV
+          - edam: http://edamontology.org/format_3475
   - db:
       type: file
       description: Kaiju database file
@@ -43,13 +44,27 @@ output:
           description: Krona text-based input file converted from Kaiju report
           pattern: "*.{txt,krona}"
           ontologies: []
+  versions_kaiju:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - kaiju:
+          type: string
+          description: The name of the tool
+      - kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - kaiju:
+          type: string
+          description: The name of the tool
+      - kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@MillironX"
 maintainers:

--- a/modules/nf-core/kaiju/kaiju2krona/tests/main.nf.test
+++ b/modules/nf-core/kaiju/kaiju2krona/tests/main.nf.test
@@ -32,7 +32,17 @@ nextflow_process {
                             [ id:'test', single_end:true ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                             ]
-                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    input[1] = UNTAR.out.untar
+                        .map {
+                            meta, untar ->
+                                def db = [
+                                    untar,
+                                    file(params.modules_testdata_base_path + "delete_me/kaiju/nodes.dmp", checkIfExists: true),
+                                    file(params.modules_testdata_base_path + "delete_me/kaiju/names.dmp", checkIfExists: true)
+                                ]
+                            [meta, db ]
+                        }
+                        .map{ it[1] }
                     """
                 }
             }
@@ -78,7 +88,17 @@ nextflow_process {
                             [ id:'test', single_end:true ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                             ]
-                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    input[1] = UNTAR.out.untar
+                        .map {
+                            meta, untar ->
+                                def db = [
+                                    untar,
+                                    file(params.modules_testdata_base_path + "delete_me/kaiju/nodes.dmp", checkIfExists: true),
+                                    file(params.modules_testdata_base_path + "delete_me/kaiju/names.dmp", checkIfExists: true)
+                                ]
+                            [meta, db ]
+                        }
+                        .map{ it[1] }
                     """
                 }
             }

--- a/modules/nf-core/kaiju/kaiju2krona/tests/main.nf.test.snap
+++ b/modules/nf-core/kaiju/kaiju2krona/tests/main.nf.test.snap
@@ -3,6 +3,10 @@
         "content": [
             "test.txt"
         ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
         "timestamp": "2024-01-20T15:06:32.789121011"
     },
     "sarscov2 - fastq - single-end": {
@@ -18,7 +22,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,f75aa349971d581981d3a0399450b395"
+                    [
+                        "KAIJU_KAIJU2KRONA",
+                        "kaiju",
+                        "1.10.0"
+                    ]
                 ],
                 "txt": [
                     [
@@ -29,11 +37,19 @@
                         "test.txt:md5,68b2309d37767e444193fa6cea7c0494"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,f75aa349971d581981d3a0399450b395"
+                "versions_kaiju": [
+                    [
+                        "KAIJU_KAIJU2KRONA",
+                        "kaiju",
+                        "1.10.0"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2024-01-20T15:06:08.840865115"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-15T14:43:28.906858483"
     }
 }

--- a/modules/nf-core/kaiju/kaiju2table/main.nf
+++ b/modules/nf-core/kaiju/kaiju2table/main.nf
@@ -1,11 +1,11 @@
 process KAIJU_KAIJU2TABLE {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0':
-        'biocontainers/kaiju:1.10.0--h43eeafb_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/kaiju:1.10.0--h43eeafb_0'
+        : 'quay.io/biocontainers/kaiju:1.10.0--h43eeafb_0'}"
 
     input:
     tuple val(meta), path(input)
@@ -14,7 +14,7 @@ process KAIJU_KAIJU2TABLE {
 
     output:
     tuple val(meta), path('*.txt'), emit: summary
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('kaiju'), eval("kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //'"), emit: versions_kaiju, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -25,28 +25,17 @@ process KAIJU_KAIJU2TABLE {
     """
     dbnodes=`find -L ${db} -name "*nodes.dmp"`
     dbnames=`find -L ${db} -name "*names.dmp"`
-    kaiju2table   $args \\
+    kaiju2table   ${args} \\
         -t \$dbnodes \\
         -n \$dbnames \\
         -r ${taxon_rank} \\
         -o ${prefix}.txt \\
         ${input}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kaiju: \$(echo \$( kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //' ))
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/kaiju/kaiju2table/meta.yml
+++ b/modules/nf-core/kaiju/kaiju2table/meta.yml
@@ -11,7 +11,8 @@ tools:
       documentation: https://github.com/bioinformatics-centre/kaiju/blob/master/README.md
       tool_dev_url: https://github.com/bioinformatics-centre/kaiju
       doi: "10.1038/ncomms11257"
-      licence: ["GNU GPL v3"]
+      licence:
+        - "GNU GPL v3"
       identifier: biotools:kaiju
 input:
   - - meta:
@@ -44,13 +45,27 @@ output:
           description: Kaiju output file
           pattern: "*.txt"
           ontologies: []
+  versions_kaiju:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - kaiju:
+          type: string
+          description: The name of the tool
+      - kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - kaiju:
+          type: string
+          description: The name of the tool
+      - kaiju -h 2>&1 | sed -n 1p | sed 's/^.*Kaiju //':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@sofstam"
   - "@talnor"

--- a/modules/nf-core/kaiju/kaiju2table/tests/main.nf.test
+++ b/modules/nf-core/kaiju/kaiju2table/tests/main.nf.test
@@ -32,7 +32,17 @@ nextflow_process {
                             [ id:'test', single_end:true ], // meta map
                             file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
                             ]
-                    input[1] = UNTAR.out.untar.map{ it[1] }
+                    input[1] = UNTAR.out.untar
+                        .map {
+                            meta, untar ->
+                                def db = [
+                                    untar,
+                                    file(params.modules_testdata_base_path + "delete_me/kaiju/nodes.dmp", checkIfExists: true),
+                                    file(params.modules_testdata_base_path + "delete_me/kaiju/names.dmp", checkIfExists: true)
+                                ]
+                            [meta, db ]
+                        }
+                        .map{ it[1] }
                     """
                 }
             }

--- a/modules/nf-core/kaiju/kaiju2table/tests/main.nf.test.snap
+++ b/modules/nf-core/kaiju/kaiju2table/tests/main.nf.test.snap
@@ -3,6 +3,10 @@
         "content": [
             "test.txt"
         ],
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
         "timestamp": "2024-01-20T16:10:49.521322767"
     },
     "sarscov2 - fastq - single-end": {
@@ -18,7 +22,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,2b2b98cb635a611e5eb964e5a77f6248"
+                    [
+                        "KAIJU_KAIJU2TABLE",
+                        "kaiju",
+                        "1.10.0"
+                    ]
                 ],
                 "summary": [
                     [
@@ -29,11 +37,19 @@
                         "test.txt:md5,0d9f8fd36fcf2888296ae12632c5f0a8"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,2b2b98cb635a611e5eb964e5a77f6248"
+                "versions_kaiju": [
+                    [
+                        "KAIJU_KAIJU2TABLE",
+                        "kaiju",
+                        "1.10.0"
+                    ]
                 ]
             }
         ],
-        "timestamp": "2024-01-20T16:08:47.644443775"
+        "meta": {
+            "nf-test": "0.9.2",
+            "nextflow": "25.10.4"
+        },
+        "timestamp": "2026-04-15T14:43:46.226835271"
     }
 }

--- a/modules/nf-core/kraken2/kraken2/environment.yml
+++ b/modules/nf-core/kraken2/kraken2/environment.yml
@@ -4,6 +4,6 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::kraken2=2.1.5
-  - coreutils=9.4
+  - bioconda::kraken2=2.1.6
+  - coreutils=9.5
   - pigz=2.8

--- a/modules/nf-core/kraken2/kraken2/main.nf
+++ b/modules/nf-core/kraken2/kraken2/main.nf
@@ -3,9 +3,9 @@ process KRAKEN2_KRAKEN2 {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/29/29ed8f68315625eca61a3de9fcb7b8739fe8da23f5779eda3792b9d276aa3b8f/data' :
-        'community.wave.seqera.io/library/kraken2_coreutils_pigz:45764814c4bb5bf3' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/0f/0f827dcea51be6b5c32255167caa2dfb65607caecdc8b067abd6b71c267e2e82/data' :
+        'community.wave.seqera.io/library/kraken2_coreutils_pigz:920ecc6b96e2ba71' }"
 
     input:
     tuple val(meta), path(reads)
@@ -18,7 +18,8 @@ process KRAKEN2_KRAKEN2 {
     tuple val(meta), path('*.unclassified{.,_}*')   , optional:true, emit: unclassified_reads_fastq
     tuple val(meta), path('*classifiedreads.txt')   , optional:true, emit: classified_reads_assignment
     tuple val(meta), path('*report.txt')                           , emit: report
-    path "versions.yml"                                            , emit: versions
+    tuple val("${task.process}"), val('kraken2'), eval('kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//"'), topic: versions, emit: versions_kraken2
+    tuple val("${task.process}"), val('pigz'), eval('pigz --version 2>&1 | sed "s/pigz //g"'), topic: versions, emit: versions_pigz
 
     when:
     task.ext.when == null || task.ext.when
@@ -48,22 +49,12 @@ process KRAKEN2_KRAKEN2 {
         $reads
 
     $compress_reads_command
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def paired       = meta.single_end ? "" : "--paired"
     def classified   = meta.single_end ? "${prefix}.classified.fastq.gz"   : "${prefix}.classified_1.fastq.gz ${prefix}.classified_2.fastq.gz"
     def unclassified = meta.single_end ? "${prefix}.unclassified.fastq.gz" : "${prefix}.unclassified_1.fastq.gz ${prefix}.unclassified_2.fastq.gz"
-    def readclassification_option = save_reads_assignment ? "--output ${prefix}.kraken2.classifiedreads.txt" : "--output /dev/null"
-    def compress_reads_command = save_output_fastqs ? "pigz -p $task.cpus *.fastq" : ""
 
     """
     touch ${prefix}.kraken2.report.txt
@@ -74,12 +65,6 @@ process KRAKEN2_KRAKEN2 {
     if [ "$save_reads_assignment" == "true" ]; then
         touch ${prefix}.kraken2.classifiedreads.txt
     fi
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kraken2: \$(echo \$(kraken2 --version 2>&1) | sed 's/^.*Kraken version //; s/ .*\$//')
-        pigz: \$( pigz --version 2>&1 | sed 's/pigz //g' )
-    END_VERSIONS
     """
 
 }

--- a/modules/nf-core/kraken2/kraken2/meta.yml
+++ b/modules/nf-core/kraken2/kraken2/meta.yml
@@ -12,6 +12,11 @@ tools:
       homepage: https://ccb.jhu.edu/software/kraken2/
       documentation: https://github.com/DerrickWood/kraken2/wiki/Manual
       doi: 10.1186/s13059-019-1891-0
+      publication:
+        author: "Wood D.E., Lu J. & Langmead B."
+        year: 2019
+        title: "Improved metagenomic analysis with Kraken 2"
+        source: "Genome Biology"
       licence: ["MIT"]
       identifier: biotools:kraken2
 input:
@@ -91,13 +96,48 @@ output:
             and not classified reads.
           pattern: "*.{report.txt}"
           ontologies: []
+  versions_kraken2:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - kraken2:
+          type: string
+          description: The tool name
+      - kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+  versions_pigz:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - pigz:
+          type: string
+          description: The tool name
+      - pigz --version 2>&1 | sed "s/pigz //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - kraken2:
+          type: string
+          description: The tool name
+      - kraken2 --version 2>&1 | head -1 | sed "s/^.*Kraken version //; s/ .*//":
+          type: eval
+          description: The expression to obtain the version of the tool
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - pigz:
+          type: string
+          description: The tool name
+      - pigz --version 2>&1 | sed "s/pigz //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@joseespinosa"
   - "@drpatelh"

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test
@@ -48,7 +48,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1) ==~ ".*/test.classified.fastq.gz" },
@@ -91,7 +91,7 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                 ).match()
             },
             { assert process.out.classified_reads_fastq.get(0).get(1).get(0)
@@ -133,10 +133,80 @@ nextflow_process {
             { assert process.success },
             { assert snapshot(
                     process.out.report,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                     process.out.classified_reads_assignment,
-                    process.out.versions,
                 ).match()
             },
+            )
+        }
+    }
+
+    test("single_end - stub") {
+
+    tag "stub"
+    options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:true ], // meta map
+                    [ file("dummy1", checkIfExists: false)]
+                ]
+                input[1] = file("dummy2", checkIfExists: false)
+                input[2] = true
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(
+                    process.out.report,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match()
+            },
+            { assert process.out.classified_reads_fastq.get(0).get(1) ==~ ".*/test.classified.fastq.gz" },
+            { assert process.out.unclassified_reads_fastq.get(0).get(1) ==~ ".*/test.unclassified.fastq.gz" },
+            )
+        }
+    }
+
+    test("paired_end - stub") {
+
+    tag "stub"
+    options "-stub"
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test', single_end:false ], // meta map
+                    [ file("dummy1", checkIfExists: false)]
+                ]
+                input[1] = file("dummy2", checkIfExists: false)
+                input[2] = true
+                input[3] = false
+                """
+            }
+        }
+
+        then {
+            assertAll(
+            { assert process.success },
+            { assert snapshot(
+                    process.out.report,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
+                ).match()
+            },
+            { assert process.out.classified_reads_fastq.get(0).get(1).get(0)
+                ==~ ".*/test.classified_1.fastq.gz" },
+            { assert process.out.classified_reads_fastq.get(0).get(1).get(1)
+                ==~ ".*/test.classified_2.fastq.gz" },
+            { assert process.out.unclassified_reads_fastq.get(0).get(1).get(0)
+                ==~ ".*/test.unclassified_1.fastq.gz" },
+            { assert process.out.unclassified_reads_fastq.get(0).get(1).get(1)
+                ==~ ".*/test.unclassified_2.fastq.gz" },
             )
         }
     }

--- a/modules/nf-core/kraken2/kraken2/tests/main.nf.test.snap
+++ b/modules/nf-core/kraken2/kraken2/tests/main.nf.test.snap
@@ -10,15 +10,62 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
-            [
-                "versions.yml:md5,ed58d544fca4d012d5477858c986d741"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:05:44.695905"
+        "timestamp": "2026-01-19T17:22:36.682041524"
+    },
+    "paired_end - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": false
+                    },
+                    "test.kraken2.report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-19T17:22:59.824433284"
     },
     "sarscov2 illumina paired end [fastq]": {
         "content": [
@@ -31,15 +78,28 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
-            [
-                "versions.yml:md5,ed58d544fca4d012d5477858c986d741"
-            ]
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:05:56.337945"
+        "timestamp": "2026-01-19T17:22:42.807626617"
     },
     "sarscov2 illumina single end [fastq] + save_reads_assignment": {
         "content": [
@@ -52,6 +112,22 @@
                     "test.kraken2.report.txt:md5,4227755fe40478b8d7dc8634b489761e"
                 ]
             ],
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            },
             [
                 [
                     {
@@ -60,15 +136,46 @@
                     },
                     "test.kraken2.classifiedreads.txt:md5,e7a90531f0d8d777316515c36fe4cae0"
                 ]
-            ],
-            [
-                "versions.yml:md5,ed58d544fca4d012d5477858c986d741"
             ]
         ],
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.2"
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
         },
-        "timestamp": "2025-06-02T13:06:07.865635"
+        "timestamp": "2026-01-19T17:22:48.87201447"
+    },
+    "single_end - stub": {
+        "content": [
+            [
+                [
+                    {
+                        "id": "test",
+                        "single_end": true
+                    },
+                    "test.kraken2.report.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                ]
+            ],
+            {
+                "versions_kraken2": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "kraken2",
+                        "2.1.6"
+                    ]
+                ],
+                "versions_pigz": [
+                    [
+                        "KRAKEN2_KRAKEN2",
+                        "pigz",
+                        "2.8"
+                    ]
+                ]
+            }
+        ],
+        "meta": {
+            "nf-test": "0.9.3",
+            "nextflow": "25.10.2"
+        },
+        "timestamp": "2026-01-19T17:22:54.351663948"
     }
 }

--- a/modules/nf-core/krakentools/combinekreports/environment.yml
+++ b/modules/nf-core/krakentools/combinekreports/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::krakentools=1.2
+  - bioconda::krakentools=1.2.1

--- a/modules/nf-core/krakentools/combinekreports/main.nf
+++ b/modules/nf-core/krakentools/combinekreports/main.nf
@@ -2,16 +2,17 @@ process KRAKENTOOLS_COMBINEKREPORTS {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/krakentools:1.2--pyh5e36f6f_0':
-        'biocontainers/krakentools:1.2--pyh5e36f6f_0' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/krakentools:1.2.1--pyh7e72e81_0':
+        'quay.io/biocontainers/krakentools:1.2.1--pyh7e72e81_0'}"
 
     input:
     tuple val(meta), path(kreports)
 
     output:
     tuple val(meta), path("*.txt"), emit: txt
-    path "versions.yml", emit: versions
+    // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    tuple val("${task.process}"), val('krakentools'), val('1.2.1'), topic: versions, emit: versions_krakentools
 
     when:
     task.ext.when == null || task.ext.when
@@ -19,29 +20,16 @@ process KRAKENTOOLS_COMBINEKREPORTS {
     script:
     def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     combine_kreports.py \\
         -r ${kreports} \\
         -o ${prefix}.txt \\
         ${args}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        combine_kreports.py: ${VERSION}
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     touch ${prefix}.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        combine_kreports.py: ${VERSION}
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/krakentools/combinekreports/meta.yml
+++ b/modules/nf-core/krakentools/combinekreports/meta.yml
@@ -1,6 +1,6 @@
 name: krakentools_combinekreports
-description: Takes multiple kraken-style reports and combines them into a single report
-  file
+description: Takes multiple kraken-style reports and combines them into a single
+  report file
 keywords:
   - kraken
   - krakentools
@@ -10,11 +10,12 @@ keywords:
   - merging
 tools:
   - krakentools:
-      description: KrakenTools is a suite of scripts to be used for post-analysis of
-        Kraken/KrakenUniq/Kraken2/Bracken results. Please cite the relevant paper if
-        using KrakenTools with any of the listed programs.
+      description: KrakenTools is a suite of scripts to be used for post-analysis
+        of Kraken/KrakenUniq/Kraken2/Bracken results. Please cite the relevant
+        paper if using KrakenTools with any of the listed programs.
       homepage: https://github.com/jenniferlu717/KrakenTools
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: biotools:krakentools
 input:
   - - meta:
@@ -39,13 +40,27 @@ output:
           description: Combined kreport file of all input files
           pattern: "*.txt"
           ontologies: []
+  versions_krakentools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - krakentools:
+          type: string
+          description: The name of the tool
+      - 1.2.1:
+          type: string
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - krakentools:
+          type: string
+          description: The name of the tool
+      - 1.2.1:
+          type: string
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/krakentools/combinekreports/tests/main.nf.test
+++ b/modules/nf-core/krakentools/combinekreports/tests/main.nf.test
@@ -25,7 +25,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot ( process.out ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 
@@ -48,7 +48,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot ( process.out ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/krakentools/combinekreports/tests/main.nf.test.snap
+++ b/modules/nf-core/krakentools/combinekreports/tests/main.nf.test.snap
@@ -2,50 +2,32 @@
     "sarscov2 - metagenome - kraken report": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.txt:md5,481c4b987b922979baf74f2ce8d88b02"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,a907962abbd9f5dcd34c9e8a4e6100d0"
-                ],
                 "txt": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.txt:md5,481c4b987b922979baf74f2ce8d88b02"
+                        "test.txt:md5,c231bfcdde47a43336a418b21bb2f98d"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,a907962abbd9f5dcd34c9e8a4e6100d0"
+                "versions_krakentools": [
+                    [
+                        "KRAKENTOOLS_COMBINEKREPORTS",
+                        "krakentools",
+                        "1.2.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-08T14:25:49.747771036",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-08-07T09:12:42.382189"
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.0"
+        }
     },
     "sarscov2 - metagenome - kraken report - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,a907962abbd9f5dcd34c9e8a4e6100d0"
-                ],
                 "txt": [
                     [
                         {
@@ -54,15 +36,19 @@
                         "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,a907962abbd9f5dcd34c9e8a4e6100d0"
+                "versions_krakentools": [
+                    [
+                        "KRAKENTOOLS_COMBINEKREPORTS",
+                        "krakentools",
+                        "1.2.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-08T14:25:54.267340399",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-08-07T09:12:46.705759"
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.0"
+        }
     }
 }

--- a/modules/nf-core/krakentools/kreport2krona/environment.yml
+++ b/modules/nf-core/krakentools/kreport2krona/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::krakentools=1.2
+  - bioconda::krakentools=1.2.1

--- a/modules/nf-core/krakentools/kreport2krona/main.nf
+++ b/modules/nf-core/krakentools/kreport2krona/main.nf
@@ -4,16 +4,17 @@ process KRAKENTOOLS_KREPORT2KRONA {
 
     // WARN: Version information not provided by tool on CLI. Please update version string below when bumping container versions.
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/krakentools:1.2--pyh5e36f6f_0':
-        'biocontainers/krakentools:1.2--pyh5e36f6f_0' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/krakentools:1.2.1--pyh7e72e81_0':
+        'quay.io/biocontainers/krakentools:1.2.1--pyh7e72e81_0'}"
 
     input:
     tuple val(meta), path(kreport)
 
     output:
     tuple val(meta), path("*.txt"), emit: txt
-    path "versions.yml", emit: versions
+    // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
+    tuple val("${task.process}"), val('krakentools'), val('1.2.1'), topic: versions, emit: versions_krakentools
 
     when:
     task.ext.when == null || task.ext.when
@@ -21,29 +22,16 @@ process KRAKENTOOLS_KREPORT2KRONA {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     kreport2krona.py \\
         -r ${kreport} \\
         -o ${prefix}.txt \\
         ${args}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kreport2krona.py: ${VERSION}
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def VERSION = '1.2' // WARN: Version information not provided by tool on CLI. Please update this string when bumping container versions.
     """
     touch ${prefix}.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        kreport2krona.py: ${VERSION}
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/krakentools/kreport2krona/meta.yml
+++ b/modules/nf-core/krakentools/kreport2krona/meta.yml
@@ -1,5 +1,6 @@
 name: krakentools_kreport2krona
-description: Takes a Kraken report file and prints out a krona-compatible TEXT file
+description: Takes a Kraken report file and prints out a krona-compatible TEXT
+  file
 keywords:
   - kraken
   - krona
@@ -7,11 +8,12 @@ keywords:
   - visualization
 tools:
   - krakentools:
-      description: KrakenTools is a suite of scripts to be used for post-analysis of
-        Kraken/KrakenUniq/Kraken2/Bracken results. Please cite the relevant paper if
-        using KrakenTools with any of the listed programs.
+      description: KrakenTools is a suite of scripts to be used for post-analysis
+        of Kraken/KrakenUniq/Kraken2/Bracken results. Please cite the relevant
+        paper if using KrakenTools with any of the listed programs.
       homepage: https://github.com/jenniferlu717/KrakenTools
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: biotools:krakentools
 input:
   - - meta:
@@ -36,13 +38,27 @@ output:
           description: Krona text-based input file converted from Kraken report
           pattern: "*.{txt,krona}"
           ontologies: []
+  versions_krakentools:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - krakentools:
+          type: string
+          description: The name of the tool
+      - 1.2.1:
+          type: string
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - krakentools:
+          type: string
+          description: The name of the tool
+      - 1.2.1:
+          type: string
+          description: The expression to obtain the version of the tool
 authors:
   - "@MillironX"
 maintainers:

--- a/modules/nf-core/krakentools/kreport2krona/tests/main.nf.test
+++ b/modules/nf-core/krakentools/kreport2krona/tests/main.nf.test
@@ -16,13 +16,10 @@ nextflow_process {
             script "modules/nf-core/untar/main.nf"
             process {
                 """
-                input[0] = Channel.of([
+                input[0] = [
                     [],
-                    file(
-                        params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kraken2.tar.gz',
-                        checkIfExists: true
-                    )
-                ])
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/db/kraken2.tar.gz', checkIfExists: true)
+                ]
                 """
             }
         }
@@ -30,13 +27,10 @@ nextflow_process {
             script "modules/nf-core/kraken2/kraken2/main.nf"
             process {
                 """
-                input[0] = Channel.of([
-                    [ id:'test', single_end:true ], // meta map
-                    file(
-                        params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz',
-                        checkIfExists: true
-                    )
-                ])
+                input[0] = [
+                    [ id:'test', single_end:true ],
+                    file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_1.fastq.gz', checkIfExists: true)
+                ]
                 input[1] = UNTAR.out.untar.map{ it[1] }
                 input[2] = false
                 input[3] = false
@@ -58,7 +52,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -78,7 +72,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/krakentools/kreport2krona/tests/main.nf.test.snap
+++ b/modules/nf-core/krakentools/kreport2krona/tests/main.nf.test.snap
@@ -2,18 +2,6 @@
     "sarscov2 illumina single end [fastq]": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.txt:md5,c89a9db7acbdba9dea0fe246bcaa85c1"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,f4a5d570efec153ab0de3da130394cbb"
-                ],
                 "txt": [
                     [
                         {
@@ -23,32 +11,24 @@
                         "test.txt:md5,c89a9db7acbdba9dea0fe246bcaa85c1"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,f4a5d570efec153ab0de3da130394cbb"
+                "versions_krakentools": [
+                    [
+                        "KRAKENTOOLS_KREPORT2KRONA",
+                        "krakentools",
+                        "1.2.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-08T14:26:59.744807442",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "23.10.4"
-        },
-        "timestamp": "2024-08-01T21:40:46.959343186"
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.0"
+        }
     },
     "sarscov2 illumina single end [fastq] - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": true
-                        },
-                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,f4a5d570efec153ab0de3da130394cbb"
-                ],
                 "txt": [
                     [
                         {
@@ -58,15 +38,19 @@
                         "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,f4a5d570efec153ab0de3da130394cbb"
+                "versions_krakentools": [
+                    [
+                        "KRAKENTOOLS_KREPORT2KRONA",
+                        "krakentools",
+                        "1.2.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-08T14:27:07.596640246",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "23.10.4"
-        },
-        "timestamp": "2024-08-02T18:35:32.145822126"
+            "nf-test": "0.9.4",
+            "nextflow": "26.03.0"
+        }
     }
 }

--- a/modules/nf-core/malt/run/environment.yml
+++ b/modules/nf-core/malt/run/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::malt=0.61
+  - bioconda::malt=0.62

--- a/modules/nf-core/malt/run/main.nf
+++ b/modules/nf-core/malt/run/main.nf
@@ -3,19 +3,19 @@ process MALT_RUN {
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/malt:0.61--hdfd78af_0' :
-        'biocontainers/malt:0.61--hdfd78af_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/malt:0.62--hdfd78af_0'
+        : 'quay.io/biocontainers/malt:0.62--hdfd78af_0'}"
 
     input:
     tuple val(meta), path(fastqs)
-    path index
+    tuple val(meta2), path(index)
 
     output:
     tuple val(meta), path("*.rma6")                                , emit: rma6
-    tuple val(meta), path("*.{tab,text,sam,tab.gz,text.gz,sam.gz}"),  optional:true, emit: alignments
+    tuple val(meta), path("*.{tab,text,sam,tab.gz,text.gz,sam.gz}"), emit: alignments, optional:true
     tuple val(meta), path("*.log")                                 , emit: log
-    path "versions.yml"                                            , emit: versions
+    tuple val("${task.process}"), val("malt"), eval("malt-run --help |& sed '/version/!d;s/.*version //;s/,.*//'"), topic: versions, emit: versions_malt
 
     when:
     task.ext.when == null || task.ext.when
@@ -25,30 +25,19 @@ process MALT_RUN {
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     malt-run \\
-        -t $task.cpus \\
+        -t ${task.cpus} \\
         -v \\
         -o . \\
-        $args \\
+        ${args} \\
         --inFile ${fastqs.join(' ')} \\
-        --index $index/ |&tee ${prefix}-malt-run.log
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        malt: \$(malt-run --help  2>&1 | grep -o 'version.* ' | cut -f 1 -d ',' | cut -f2 -d ' ')
-    END_VERSIONS
+        --index ${index}/ |& tee ${prefix}-malt-run.log
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}-malt-run.log
     touch ${prefix}.rma6
     touch ${prefix}.sam
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        malt: \$(malt-run --help  2>&1 | grep -o 'version.* ' | cut -f 1 -d ',' | cut -f2 -d ' ')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/malt/run/meta.yml
+++ b/modules/nf-core/malt/run/meta.yml
@@ -1,7 +1,7 @@
 name: malt_run
-description: MALT, an acronym for MEGAN alignment tool, is a sequence alignment and
-  analysis tool designed for processing high-throughput sequencing data, especially
-  in the context of metagenomics.
+description: MALT, an acronym for MEGAN alignment tool, is a sequence alignment
+  and analysis tool designed for processing high-throughput sequencing data,
+  especially in the context of metagenomics.
 keywords:
   - malt
   - alignment
@@ -17,7 +17,8 @@ tools:
       homepage: https://www.wsi.uni-tuebingen.de/lehrstuehle/algorithms-in-bioinformatics/software/malt/
       documentation: https://software-ab.cs.uni-tuebingen.de/download/malt/manual.pdf
       doi: "10.1038/s41559-017-0446-6"
-      licence: ["GPL v3"]
+      licence:
+        - "GPL v3"
       identifier: ""
 input:
   - - meta:
@@ -30,10 +31,15 @@ input:
         description: Input FASTQ files
         pattern: "*.{fastq.gz,fq.gz}"
         ontologies: []
-  - index:
-      type: directory
-      description: Index/database directory from malt-build
-      pattern: "*/"
+  - - meta2:
+        type: map
+        description: |
+          Groovy Map containing sample information
+          e.g. [ id:'test', single_end:false ]
+    - index:
+        type: directory
+        description: Index/database directory from malt-build
+        pattern: "*/"
 output:
   rma6:
     - - meta:
@@ -69,13 +75,27 @@ output:
           description: Log of verbose MALT stdout
           pattern: "*-malt-run.log"
           ontologies: []
+  versions_malt:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - malt:
+          type: string
+          description: The name of the tool
+      - malt-run --help |& sed '/version/!d;s/.*version //;s/,.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - malt:
+          type: string
+          description: The name of the tool
+      - malt-run --help |& sed '/version/!d;s/.*version //;s/,.*//':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/malt/run/tests/main.nf.test
+++ b/modules/nf-core/malt/run/tests/main.nf.test
@@ -18,7 +18,7 @@ nextflow_process {
             config './nextflow.config'
             process {
                 """
-                input[0] = [[], file("https://ngi-igenomes.s3.eu-west-1.amazonaws.com/test-data/createtaxdb/taxonomy/megan-nucl-Feb2022.db.zip", checkIfExists: true)]
+                input[0] = [[], file("s3://nf-core-test-datasets/modules/data/delete_me/malt/megan-nucl-Feb2022.db.zip", checkIfExists: true)]
                 """
             }
         }
@@ -27,7 +27,10 @@ nextflow_process {
             config './nextflow.config'
             process {
                 """
-                input[0] = file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true)
+                input[0] = [
+                    [id: "genome"],
+                    file(params.modules_testdata_base_path + "genomics/sarscov2/genome/genome.fasta", checkIfExists: true)
+                ]
                 input[1] = []
                 input[2] = UNZIP.out.unzipped_archive.map { it[1] }
                 input[3] = 'mdb'
@@ -55,12 +58,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(
-                        process.out.alignments,
-                        process.out.versions,
-                        file(process.out.rma6[0][1]).name
-                    ).match()
-                },
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["rma6", "log"])).match() },
                 { assert path(process.out.log[0][1]).readLines().last().contains("Peak memory") },
             )
         }
@@ -88,7 +86,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/malt/run/tests/main.nf.test.snap
+++ b/modules/nf-core/malt/run/tests/main.nf.test.snap
@@ -2,36 +2,6 @@
     "sarscov2 - fastq - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test_1",
-                            "single_end": false
-                        },
-                        "test_1.rma6:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test_1",
-                            "single_end": false
-                        },
-                        "test_1.sam:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test_1",
-                            "single_end": false
-                        },
-                        "test_1-malt-run.log:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    "versions.yml:md5,5b91a785e0342f9ef17a634c0452335a"
-                ],
                 "alignments": [
                     [
                         {
@@ -59,37 +29,64 @@
                         "test_1.rma6:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,5b91a785e0342f9ef17a634c0452335a"
+                "versions_malt": [
+                    [
+                        "MALT_RUN",
+                        "malt",
+                        "0.6.2"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-23T14:03:16.041446556",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
-        },
-        "timestamp": "2024-01-26T14:15:43.18685293"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     },
     "sarscov2 - fastq": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test_1",
-                        "single_end": false
-                    },
-                    "test_1.blastn.sam.gz:md5,8ad56803c1674e1a8cd42fe8801e71fd"
+            {
+                "alignments": [
+                    [
+                        {
+                            "id": "test_1",
+                            "single_end": false
+                        },
+                        "test_1.blastn.sam.gz:md5,8ad56803c1674e1a8cd42fe8801e71fd"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test_1",
+                            "single_end": false
+                        },
+                        "test_1-malt-run.log"
+                    ]
+                ],
+                "rma6": [
+                    [
+                        {
+                            "id": "test_1",
+                            "single_end": false
+                        },
+                        "test_1.rma6"
+                    ]
+                ],
+                "versions_malt": [
+                    [
+                        "MALT_RUN",
+                        "malt",
+                        "0.6.2"
+                    ]
                 ]
-            ],
-            [
-                "versions.yml:md5,5b91a785e0342f9ef17a634c0452335a"
-            ],
-            "test_1.rma6"
+            }
         ],
+        "timestamp": "2026-06-23T14:01:40.218634909",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.2"
-        },
-        "timestamp": "2024-06-30T07:04:07.674069223"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }

--- a/modules/nf-core/megan/rma2info/main.nf
+++ b/modules/nf-core/megan/rma2info/main.nf
@@ -3,18 +3,18 @@ process MEGAN_RMA2INFO {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/megan:6.25.9--h9ee0642_0':
-        'biocontainers/megan:6.25.9--h9ee0642_0' }"
+        'quay.io/biocontainers/megan:6.25.9--h9ee0642_0' }"
 
     input:
     tuple val(meta), path(rma6)
     val(megan_summary)
 
     output:
-    tuple val(meta), path("*.txt.gz")               , emit: txt
-    tuple val(meta), path("*.megan"), optional: true, emit: megan_summary
-    path "versions.yml"                             , emit: versions
+    tuple val(meta), path("*.txt.gz"), emit: txt
+    tuple val(meta), path("*.megan") , emit: megan_summary, optional: true
+    tuple val("${task.process}"), val('megan'), eval("rma2info 2>&1 | sed -n 's/.*version \\([^,]*\\).*/\\1/p'"), emit: versions_megan, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -28,24 +28,13 @@ process MEGAN_RMA2INFO {
         -i ${rma6} \\
         -o ${prefix}.txt.gz \\
         ${summary} \\
-        $args
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        megan: \$(echo \$(rma2info 2>&1) | grep version | sed 's/.*version //g;s/, built.*//g')
-    END_VERSIONS
+        ${args}
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def summary = megan_summary ? "-es ${prefix}.megan" : ""
     """
     echo "" | gzip > ${prefix}.txt.gz
     touch ${prefix}.megan
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        megan: \$(echo \$(rma2info 2>&1) | grep version | sed 's/.*version //g;s/, built.*//g')
-    END_VERSIONSs
     """
 }

--- a/modules/nf-core/megan/rma2info/meta.yml
+++ b/modules/nf-core/megan/rma2info/meta.yml
@@ -12,7 +12,8 @@ tools:
       documentation: "https://software-ab.cs.uni-tuebingen.de/download/megan6/welcome.html"
       tool_dev_url: "https://github.com/husonlab/megan-ce"
       doi: "10.1371/journal.pcbi.1004957"
-      licence: ["GPL >=3"]
+      licence:
+        - "GPL >=3"
       identifier: biotools:megan
 input:
   - - meta:
@@ -52,13 +53,29 @@ output:
           description: Optionally generated MEGAN summary file
           pattern: "*.megan"
           ontologies: []
+  versions_megan:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - megan:
+          type: string
+          description: The name of the tool
+      - rma2info 2>&1 | sed -n 's/.*version \([^,]*\).*/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - megan:
+          type: string
+          description: The name of the tool
+      - rma2info 2>&1 | sed -n 's/.*version \([^,]*\).*/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/megan/rma2info/tests/main.nf.test
+++ b/modules/nf-core/megan/rma2info/tests/main.nf.test
@@ -2,6 +2,7 @@ nextflow_process {
 
     name "Test Process MEGAN_RMA2INFO"
     script "../main.nf"
+    config "./nextflow.config"
     process "MEGAN_RMA2INFO"
 
     tag "modules"
@@ -10,17 +11,13 @@ nextflow_process {
     tag "megan/rma2info"
 
     test("malt - rma") {
-
-        config "./nextflow.config"
-
         when {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'delete_me/malt/test.rma6', checkIfExists: true)
                 ]
-
                 input[1] = 'true'
                 """
             }
@@ -29,25 +26,20 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot ( process.out.versions ).match() },
-                { assert file (process.out.txt.get(0).get(1)).exists() }
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys:["txt", "megan_summary"])).match() }
             )
         }
     }
 
     test("malt - rma - stub") {
-
         options "-stub"
-        config "./nextflow.config"
-
         when {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:false ], // meta map
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'delete_me/malt/test.rma6', checkIfExists: true)
                 ]
-
                 input[1] = 'true'
                 """
             }
@@ -56,7 +48,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot ( process.out ).match() },
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/megan/rma2info/tests/main.nf.test.snap
+++ b/modules/nf-core/megan/rma2info/tests/main.nf.test.snap
@@ -1,45 +1,45 @@
 {
     "malt - rma": {
         "content": [
-            [
-                "versions.yml:md5,b27ee982b4ec7793e8c3ff9f59e239e5"
-            ]
+            {
+                "megan_summary": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.megan"
+                    ]
+                ],
+                "txt": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.txt.gz"
+                    ]
+                ],
+                "versions_megan": [
+                    [
+                        "MEGAN_RMA2INFO",
+                        "megan",
+                        "6.25.9"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-07-06T10:14:05.941099305",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-08-09T14:30:14.141999"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     },
     "malt - rma - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.txt.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.megan:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    "versions.yml:md5,13888803285f4a513973f3ced50f26b9"
-                ],
                 "megan_summary": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
                         "test.megan:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
@@ -47,21 +47,24 @@
                 "txt": [
                     [
                         {
-                            "id": "test",
-                            "single_end": false
+                            "id": "test"
                         },
                         "test.txt.gz:md5,68b329da9893e34099c7d8ad5cb9c940"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,13888803285f4a513973f3ced50f26b9"
+                "versions_megan": [
+                    [
+                        "MEGAN_RMA2INFO",
+                        "megan",
+                        "6.25.9"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-07-02T17:18:11.208982695",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-08-09T14:30:25.993511"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }

--- a/modules/nf-core/megan/rma2info/tests/nextflow.config
+++ b/modules/nf-core/megan/rma2info/tests/nextflow.config
@@ -1,3 +1,5 @@
 process {
-    ext.args = '-c2c Taxonomy'
+    withName: "MEGAN_RMA2INFO" {
+        ext.args = '-c2c Taxonomy'
+    }
 }

--- a/modules/nf-core/melon/environment.yml
+++ b/modules/nf-core/melon/environment.yml
@@ -4,4 +4,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::melon=0.2.5"
+  - bioconda::diamond=2.1.10
+  - bioconda::melon=0.2.5

--- a/modules/nf-core/melon/main.nf
+++ b/modules/nf-core/melon/main.nf
@@ -3,9 +3,9 @@ process MELON {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/melon:0.2.5--pyhdfd78af_0':
-        'biocontainers/melon:0.2.5--pyhdfd78af_0' }"
+        'quay.io/biocontainers/melon:0.2.5--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(reads)
@@ -13,10 +13,11 @@ process MELON {
     path(k2_db)
 
     output:
-    tuple val(meta), path("${prefix}/*.tsv")    , emit: tsv_output
-    tuple val(meta), path("${prefix}/*.json")   , emit: json_output
-    tuple val(meta), path("${prefix}.log")      , emit: log
-    path "versions.yml"                         , emit: versions
+    tuple val(meta), path("${prefix}/*.tsv") , emit: tsv_output
+    tuple val(meta), path("${prefix}/*.json"), emit: json_output
+    tuple val(meta), path("${prefix}.log")   , emit: log
+    tuple val("${task.process}"), val("melon"), eval("melon -v"), emit: versions_melon, topic: versions
+    tuple val("${task.process}"), val("diamond"), eval("diamond version | sed 's/.* version //'"), emit: versions_diamond, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -24,35 +25,24 @@ process MELON {
     script:
     def args = task.ext.args ?: ''
     prefix   = task.ext.prefix ?: "${meta.id}"
-    def k2_db_arg = k2_db ? "--db-kraken $k2_db" : ''
+    def k2_db_arg = k2_db ? "--db-kraken ${k2_db}" : ''
     """
     melon \\
-        $reads \\
-        --db $database \\
+        ${reads} \\
+        --db ${database} \\
         --output ${prefix} \\
-        --threads $task.cpus \\
-        $k2_db_arg \\
-        $args \\
-        2> >(tee ${prefix}.log >&2)
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        melon: \$(melon -v)
-    END_VERSIONS
+        --threads ${task.cpus} \\
+        ${k2_db_arg} \\
+        ${args} \\
+        2>| >(tee ${prefix}.log >&2)
     """
 
     stub:
-    def args = task.ext.args ?: ''
     prefix   = task.ext.prefix ?: "${meta.id}"
     """
     mkdir -p ${prefix}
     touch ${prefix}/${prefix}.tsv
     touch ${prefix}/${prefix}.json
     touch ${prefix}.log
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        melon: \$(melon -v)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/melon/meta.yml
+++ b/modules/nf-core/melon/meta.yml
@@ -1,6 +1,6 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "melon"
-description: Performs taxonomic profiling of long metagenomic reads against the melon database
+description: Performs taxonomic profiling of long metagenomic reads against the
+  melon database
 keywords:
   - profile
   - metagenomics
@@ -10,12 +10,14 @@ keywords:
   - nanopore
 tools:
   - "melon":
-      description: "Melon: metagenomic long-read-based taxonomic identification and quantification using marker genes"
+      description: "Melon: metagenomic long-read-based taxonomic identification and
+        quantification using marker genes"
       homepage: "https://github.com/xinehc/melon"
       documentation: "https://github.com/xinehc/melon"
       tool_dev_url: "https://github.com/xinehc/melon"
       doi: "10.1186/s13059-024-03363-y"
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 input:
   - - meta:
@@ -27,35 +29,44 @@ input:
         type: file
         description: Quality-controlled long reads.
         pattern: "*.{fa,fasta,fas,fna,fq,fastq}{,.gz}"
-  - - database:
-        type: directory
-        description: Melon database.
-  - - k2_db:
-        type: directory
-        description: Kraken2 database for pre-filtering of non-prokaryotic reads (needs to include at least human and fungi).
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+  - database:
+      type: directory
+      description: Melon database.
+  - k2_db:
+      type: directory
+      description: Kraken2 database for pre-filtering of non-prokaryotic reads
+        (needs to include at least human and fungi).
 output:
-  - tsv_output:
-      - meta:
+  tsv_output:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'test', single_end:true ]`.
       - ${prefix}/*.tsv:
           type: file
-          description: Melon output tsv file containing taxonomic profiling results.
+          description: Melon output tsv file containing taxonomic profiling
+            results.
           pattern: "*.tsv"
-  - json_output:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  json_output:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'test', single_end:true ]`.
       - ${prefix}/*.json:
           type: file
-          description: Melon output json file containing per-read taxonomic classification results.
+          description: Melon output json file containing per-read taxonomic
+            classification results.
           pattern: "*.json"
-  - log:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_3464 # JSON
+  log:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -64,11 +75,51 @@ output:
           type: file
           description: |
             Log file containing Melon standard output.
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions.
-          pattern: "versions.yml"
+          ontologies: []
+  versions_melon:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - melon:
+          type: string
+          description: The name of the tool
+      - melon -v:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+  versions_diamond:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - diamond:
+          type: string
+          description: The name of the tool
+      - diamond version | sed 's/.* version //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - melon:
+          type: string
+          description: The name of the tool
+      - melon -v:
+          type: eval
+          description: The expression to obtain the version of the tool
+
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - diamond:
+          type: string
+          description: The name of the tool
+      - diamond version | sed 's/.* version //':
+          type: eval
+          description: The expression to obtain the version of the tool
+
 authors:
   - "@eparisis"
 maintainers:

--- a/modules/nf-core/melon/tests/main.nf.test
+++ b/modules/nf-core/melon/tests/main.nf.test
@@ -14,13 +14,10 @@ nextflow_process {
             script "modules/nf-core/untar/main.nf"
             process {
                 """
-                input[0] = Channel.of([
+                input[0] = [
                     [],
-                    file(
-                        params.modules_testdata_base_path + 'delete_me/melon_db.tar.gz',
-                        checkIfExists: true
-                    )
-                ])
+                    file(params.modules_testdata_base_path + 'delete_me/melon_db.tar.gz', checkIfExists: true)
+                ]
                 """
             }
         }
@@ -30,12 +27,11 @@ nextflow_process {
 
         when {
             process {
-                """                
+                """
                 input[0] = [
-                    [ id:'test', single_end:true ], // meta map
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true)
                 ]
-
                 input[1] =  UNTAR.out.untar.map{ it[1] }
                 input[2] = []
                 """
@@ -45,10 +41,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.tsv_output,
-                                process.out.json_output,
-                                process.out.versions).match() },
-                { assert path(process.out.log[0][1]).exists() }
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["log"])).match() }
             )
         }
 
@@ -62,10 +55,9 @@ nextflow_process {
             process {
                 """
                 input[0] = [
-                    [ id:'test', single_end:true ], // meta map
+                    [ id:'test' ],
                     file(params.modules_testdata_base_path + 'genomics/prokaryotes/bacteroides_fragilis/nanopore/fastq/test.fastq.gz', checkIfExists: true)
                 ]
-
                 input[1] =  UNTAR.out.untar.map{ it[1] }
                 input[2] = []
                 """
@@ -75,10 +67,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot(process.out.tsv_output,
-                                process.out.json_output,
-                                process.out.versions).match() },
-                { assert path(process.out.log[0][1]).exists() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/melon/tests/main.nf.test.snap
+++ b/modules/nf-core/melon/tests/main.nf.test.snap
@@ -1,62 +1,100 @@
 {
     "bacteroides_fragilis - nanopore fastq - stub": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+            {
+                "json_output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "tsv_output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
+                ],
+                "versions_diamond": [
+                    [
+                        "MELON",
+                        "diamond",
+                        "2.1.10"
+                    ]
+                ],
+                "versions_melon": [
+                    [
+                        "MELON",
+                        "melon",
+                        "0.2.5"
+                    ]
                 ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
-                ]
-            ],
-            [
-                "versions.yml:md5,7e9e8fce7c5a0508af9d9ab89a761950"
-            ]
+            }
         ],
+        "timestamp": "2026-07-06T10:42:54.745957505",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-27T08:36:47.495829264"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     },
     "bacteroides_fragilis - nanopore fastq": {
         "content": [
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "test.tsv:md5,a040c7a1c87d39cebb17896f6f869328"
+            {
+                "json_output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.json:md5,5254e0dbe3aa85dbeda8afe934c08d4e"
+                    ]
+                ],
+                "log": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.log"
+                    ]
+                ],
+                "tsv_output": [
+                    [
+                        {
+                            "id": "test"
+                        },
+                        "test.tsv:md5,a040c7a1c87d39cebb17896f6f869328"
+                    ]
+                ],
+                "versions_diamond": [
+                    [
+                        "MELON",
+                        "diamond",
+                        "2.1.10"
+                    ]
+                ],
+                "versions_melon": [
+                    [
+                        "MELON",
+                        "melon",
+                        "0.2.5"
+                    ]
                 ]
-            ],
-            [
-                [
-                    {
-                        "id": "test",
-                        "single_end": true
-                    },
-                    "test.json:md5,5254e0dbe3aa85dbeda8afe934c08d4e"
-                ]
-            ],
-            [
-                "versions.yml:md5,7e9e8fce7c5a0508af9d9ab89a761950"
-            ]
+            }
         ],
+        "timestamp": "2026-07-06T10:42:45.463466165",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-03-27T08:36:40.160514446"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.3"
+        }
     }
 }

--- a/modules/nf-core/metacache/query/main.nf
+++ b/modules/nf-core/metacache/query/main.nf
@@ -1,22 +1,22 @@
 process METACACHE_QUERY {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_medium'
 
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/metacache:2.5.0--h077b44d_0':
-        'biocontainers/metacache:2.5.0--h077b44d_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/metacache:2.5.0--h077b44d_0'
+        : 'quay.io/biocontainers/metacache:2.5.0--h077b44d_0'}"
 
     input:
     tuple val(meta), path(reads)
     path db, stageAs: 'db/*'
-    val(do_abundances)
+    val do_abundances
 
     output:
-    tuple val(meta), path("*mapping.txt")   , emit: mapping_results
+    tuple val(meta), path("*mapping.txt"), emit: mapping_results
     tuple val(meta), path("*abundances.txt"), emit: abundances, optional: true
-    path "versions.yml"                     , emit: versions
+    tuple val("${task.process}"), val('metacache'), eval("metacache info |& sed -n 's/^MetaCache version \\+\\([0-9.]\\+\\).*\$/\\1/p'"), emit: versions_metacache, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -33,28 +33,16 @@ process METACACHE_QUERY {
         query \\
         \$dbmeta \\
         ${input_file} \\
-        $abundance_opt \\
-        $args \\
+        ${abundance_opt} \\
+        ${args} \\
         -out ${prefix}.mapping.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        metacache: \$(metacache info |& sed -n 's/^MetaCache version \\+\\([0-9.]\\+\\).*\$/\\1/p')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input_file = meta.single_end ? reads : "${reads[0]} ${reads[1]} -pairfiles"
     def abundance_opt = do_abundances ? "-abundances ${prefix}.abundances.txt" : ''
     """
     touch ${prefix}.mapping.txt
-    [ -n "$abundance_opt" ] && touch ${prefix}.abundances.txt
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-         metacache: \$(metacache info |& sed -n 's/^MetaCache version \\+\\([0-9.]\\+\\).*\$/\\1/p')
-    END_VERSIONS
+    [ -n "${abundance_opt}" ] && touch ${prefix}.abundances.txt
     """
 }

--- a/modules/nf-core/metacache/query/meta.yml
+++ b/modules/nf-core/metacache/query/meta.yml
@@ -1,4 +1,3 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/meta-schema.json
 name: "metacache_query"
 description: Metacache query command for taxonomic classification
 keywords:
@@ -14,9 +13,9 @@ tools:
       documentation: https://muellan.github.io/metacache/
       tool_dev_url: https://github.com/muellan/metacache
       doi: 10.1093/bioinformatics/btx520
-      licence: ["GPL-3.0 license"]
+      licence:
+        - "GPL-3.0 license"
       identifier: ""
-
 input:
   - - meta:
         type: map
@@ -28,7 +27,7 @@ input:
         description: FASTA or FASTQ files
         pattern: "*.{fasta,fa,fastq,fq}"
         ontologies:
-          - edam: http://edamontology.org/format_1930 # FASTQ
+          - edam: http://edamontology.org/format_1930
   - db:
       type: directory
       description: A MetaCache database contains taxonomic information and min-hash
@@ -58,16 +57,28 @@ output:
           type: file
           description: Output file showing absolute and relative abundance of each taxon
           pattern: "*abundances.txt"
-
           ontologies: []
+  versions_metacache:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - metacache:
+          type: string
+          description: The name of the tool
+      - metacache info |& sed -n 's/^MetaCache version \+\([0-9.]\+\).*\$/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - metacache:
+          type: string
+          description: The name of the tool
+      - metacache info |& sed -n 's/^MetaCache version \+\([0-9.]\+\).*\$/\1/p':
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@sofstam"
   - "@Gullumluvl"

--- a/modules/nf-core/metacache/query/tests/main.nf.test
+++ b/modules/nf-core/metacache/query/tests/main.nf.test
@@ -46,7 +46,7 @@ nextflow_process {
         then {
             assert process.success
             assert snapshot(
-                process.out.versions,
+                process.out.findAll { key, val -> key.startsWith('versions') },
                 file(process.out.mapping_results[0][1]).readLines()[0]
             ).match()
         }
@@ -97,15 +97,10 @@ nextflow_process {
         then {
             assert process.success
             assert snapshot(
-                process.out.versions,
+                process.out.findAll { key, val -> key.startsWith('versions') },
                 file(process.out.mapping_results[0][1]).readLines()[0],
                 file(process.out.abundances[0][1]).readLines()[0]
             ).match()
         }
-
     }
-
-
-
-
 }

--- a/modules/nf-core/metacache/query/tests/main.nf.test.snap
+++ b/modules/nf-core/metacache/query/tests/main.nf.test.snap
@@ -15,7 +15,11 @@
                     
                 ],
                 "2": [
-                    "versions.yml:md5,803de66366edd7630306fc5b6a2b9cf3"
+                    [
+                        "METACACHE_QUERY",
+                        "metacache",
+                        "2.5.0"
+                    ]
                 ],
                 "abundances": [
                     
@@ -29,42 +33,58 @@
                         "test.mapping.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,803de66366edd7630306fc5b6a2b9cf3"
+                "versions_metacache": [
+                    [
+                        "METACACHE_QUERY",
+                        "metacache",
+                        "2.5.0"
+                    ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-06-10T10:49:30.789756102"
+        "timestamp": "2026-04-11T07:21:06.396986529"
     },
     "sarscov2 nanopore [fastq_gz]": {
         "content": [
-            [
-                "versions.yml:md5,669526a447b62c30b8bce10f24d149b0"
-            ],
+            {
+                "versions_metacache": [
+                    [
+                        "METACACHE_QUERY",
+                        "metacache",
+                        "2.5.0"
+                    ]
+                ]
+            },
             "# Reporting per-read mappings (non-mapping lines start with '# ')."
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-06-10T10:49:18.566698159"
+        "timestamp": "2026-04-11T07:39:15.601425594"
     },
     "sarscov2 nanopore [fastq_gz] abundance": {
         "content": [
-            [
-                "versions.yml:md5,669526a447b62c30b8bce10f24d149b0"
-            ],
+            {
+                "versions_metacache": [
+                    [
+                        "METACACHE_QUERY",
+                        "metacache",
+                        "2.5.0"
+                    ]
+                ]
+            },
             "# Reporting per-read mappings (non-mapping lines start with '# ').",
             "# query summary: number of queries mapped per taxon"
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "25.04.3"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-06-10T10:49:43.725651952"
+        "timestamp": "2026-04-11T07:39:32.033444683"
     }
 }

--- a/modules/nf-core/metaphlan/mergemetaphlantables/main.nf
+++ b/modules/nf-core/metaphlan/mergemetaphlantables/main.nf
@@ -2,16 +2,16 @@ process METAPHLAN_MERGEMETAPHLANTABLES {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/metaphlan:4.1.1--pyhdfd78af_0' :
-        'biocontainers/metaphlan:4.1.1--pyhdfd78af_0' }"
+        'quay.io/biocontainers/metaphlan:4.1.1--pyhdfd78af_0' }"
 
     input:
     tuple val(meta), path(profiles)
 
     output:
     tuple val(meta), path("${prefix}.txt") , emit: txt
-    path "versions.yml"                    , emit: versions
+    tuple val("${task.process}"), val('metaphlan'), eval("metaphlan --version 2>&1 | cut -d ' ' -f 3"), emit: versions_metaphlan, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -25,21 +25,12 @@ process METAPHLAN_MERGEMETAPHLANTABLES {
         -o ${prefix}.txt \\
         ${profiles}
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        metaphlan: \$(metaphlan --version 2>&1 | awk '{print \$3}')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.txt
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        metaphlan: \$(metaphlan --version 2>&1 | awk '{print \$3}')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/metaphlan/mergemetaphlantables/meta.yml
+++ b/modules/nf-core/metaphlan/mergemetaphlantables/meta.yml
@@ -38,13 +38,27 @@ output:
           description: Combined MetaPhlAn4 table
           pattern: "*.txt"
           ontologies: []
+  versions_metaphlan:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - metaphlan:
+          type: string
+          description: The tool name
+      - "metaphlan --version 2>&1 | cut -d ' ' -f 3":
+          type: string
+          description: The command used to generate the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - metaphlan:
+          type: string
+          description: The tool name
+      - "metaphlan --version 2>&1 | cut -d ' ' -f 3":
+          type: string
+          description: The command used to generate the version of the tool
 authors:
   - "@jfy133"
   - "@LilyAnderssonLee"

--- a/modules/nf-core/metaphlan/mergemetaphlantables/tests/main.nf.test
+++ b/modules/nf-core/metaphlan/mergemetaphlantables/tests/main.nf.test
@@ -33,6 +33,7 @@ nextflow_process {
                     [ [ id: 'test2', single_end: true], file( params.modules_testdata_base_path + 'genomics/sarscov2/illumina/fastq/test_2.fastq.gz',checkIfExists: true ) ],
                 )
                 input[1] = UNTAR.out.untar.map{ it[1] }
+                input[2] = false
                 """
             }
         }
@@ -51,7 +52,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot( process.out ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }
@@ -72,7 +73,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot( process.out ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/metaphlan/mergemetaphlantables/tests/main.nf.test.snap
+++ b/modules/nf-core/metaphlan/mergemetaphlantables/tests/main.nf.test.snap
@@ -2,17 +2,6 @@
     "sarscov2 - illumina single end [fastq] - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,4687feab0c102fdc65fe2e174431a7c7"
-                ],
                 "txt": [
                     [
                         {
@@ -21,31 +10,24 @@
                         "test.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,4687feab0c102fdc65fe2e174431a7c7"
+                "versions_metaphlan": [
+                    [
+                        "METAPHLAN_MERGEMETAPHLANTABLES",
+                        "metaphlan",
+                        "4.1.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-09T17:20:41.300728872",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-15T07:57:23.888779527"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - illumina single end [fastq]": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.txt:md5,671ac0cf0c2561154fc44109b6d8b973"
-                    ]
-                ],
-                "1": [
-                    "versions.yml:md5,4687feab0c102fdc65fe2e174431a7c7"
-                ],
                 "txt": [
                     [
                         {
@@ -54,15 +36,19 @@
                         "test.txt:md5,671ac0cf0c2561154fc44109b6d8b973"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,4687feab0c102fdc65fe2e174431a7c7"
+                "versions_metaphlan": [
+                    [
+                        "METAPHLAN_MERGEMETAPHLANTABLES",
+                        "metaphlan",
+                        "4.1.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-09T17:20:25.749868614",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-15T07:53:05.914944433"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/modules/nf-core/metaphlan/metaphlan/main.nf
+++ b/modules/nf-core/metaphlan/metaphlan/main.nf
@@ -3,13 +3,13 @@ process METAPHLAN_METAPHLAN {
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/metaphlan:4.1.1--pyhdfd78af_0'
-        : 'biocontainers/metaphlan:4.1.1--pyhdfd78af_0'}"
+        : 'quay.io/biocontainers/metaphlan:4.1.1--pyhdfd78af_0'}"
 
     input:
     tuple val(meta), path(input)
-    path metaphlan_db_latest
+    path db_metaphlan_latest
     val save_samfile
 
     output:
@@ -17,7 +17,7 @@ process METAPHLAN_METAPHLAN {
     tuple val(meta), path("*.biom"), emit: biom
     tuple val(meta), path('*.bowtie2out.txt'), optional: true, emit: bt2out
     tuple val(meta), path("*.sam"), optional: true, emit: sam
-    path "versions.yml", emit: versions
+    tuple val("${task.process}"), val('metaphlan'), eval("metaphlan --version 2>&1 | cut -d ' ' -f 3"), emit: versions_metaphlan, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -30,8 +30,8 @@ process METAPHLAN_METAPHLAN {
     def bowtie2_out = "${input_type}" == "--input_type bowtie2out" || "${input_type}" == "--input_type sam" ? '' : "--bowtie2out ${prefix}.bowtie2out.txt"
     def samfile_out = save_samfile ? "-s ${prefix}.sam" : ''
     """
-    BT2_DB=`find -L "${metaphlan_db_latest}" -name "*rev.1.bt2*" -exec dirname {} \\;`
-    BT2_DB_INDEX=`find -L ${metaphlan_db_latest} -name "*.rev.1.bt2*" | sed 's/\\.rev.1.bt2.*\$//' | sed 's/.*\\///'`
+    BT2_DB=`find -L "${db_metaphlan_latest}" -name "*rev.1.bt2*" -exec dirname {} \\;`
+    BT2_DB_INDEX=`find -L ${db_metaphlan_latest} -name "*.rev.1.bt2*" | sed 's/\\.rev.1.bt2.*\$//' | sed 's/.*\\///'`
 
     metaphlan \\
         --nproc ${task.cpus} \\
@@ -45,27 +45,22 @@ process METAPHLAN_METAPHLAN {
         --biom ${prefix}.biom \\
         --output_file ${prefix}_profile.txt
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        metaphlan: \$(metaphlan --version 2>&1 | awk '{print \$3}')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input_type = "${input}" =~ /.*\.(fastq|fq)/ ? "--input_type fastq" : "${input}" =~ /.*\.(fasta|fna|fa)/ ? "--input_type fasta" : "${input}".endsWith(".bowtie2out.txt") ? "--input_type bowtie2out" : "--input_type sam"
-    def input_data = ("${input_type}".contains("fastq")) && !meta.single_end ? "${input[0]},${input[1]}" : "${input}"
-    def bowtie2_out = "${input_type}" == "--input_type bowtie2out" || "${input_type}" == "--input_type sam" ? '' : "--bowtie2out ${prefix}.bowtie2out.txt"
-    def samfile_out = save_samfile ? "-s ${prefix}.sam" : ''
+    def samfile_cmd = save_samfile ? "touch ${prefix}.sam" : ''
+    def input_type = "${input}" =~ /.*\.(fastq|fq)/ ? "fastq" :
+        "${input}" =~ /.*\.(fasta|fna|fa)/? "fasta" :
+        "${input}".endsWith(".bowtie2out.txt") ? "bowtie2out" :
+        "sam"
+    def bowtie2_cmd = "${input_type}" == "bowtie2out" || "${input_type}" == "sam" ? '' : "touch ${prefix}.bowtie2out.txt"
+
     """
-    echo "${args}"
     touch ${prefix}.biom
     touch ${prefix}_profile.txt
+    ${samfile_cmd}
+    ${bowtie2_cmd}
 
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        metaphlan: \$(metaphlan --version 2>&1 | awk '{print \$3}')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/metaphlan/metaphlan/meta.yml
+++ b/modules/nf-core/metaphlan/metaphlan/meta.yml
@@ -1,6 +1,6 @@
 name: metaphlan_metaphlan
-description: MetaPhlAn is a tool for profiling the composition of microbial communities
-  from metagenomic shotgun sequencing data.
+description: MetaPhlAn is a tool for profiling the composition of microbial
+  communities from metagenomic shotgun sequencing data.
 keywords:
   - metagenomics
   - classification
@@ -9,12 +9,13 @@ keywords:
   - sam
 tools:
   - metaphlan:
-      description: Identify clades (phyla to species) present in the metagenome obtained
-        from a microbiome sample and their relative abundance
+      description: Identify clades (phyla to species) present in the metagenome
+        obtained from a microbiome sample and their relative abundance
       homepage: https://huttenhower.sph.harvard.edu/metaphlan/
       documentation: https://github.com/biobakery/MetaPhlAn
       doi: "10.1038/s41587-023-01688-w"
-      licence: ["MIT License"]
+      licence:
+        - "MIT License"
       identifier: biotools:metaphlan
 input:
   - - meta:
@@ -24,13 +25,13 @@ input:
           e.g. [ id:'test', single_end:false ]
     - input:
         type: file
-        description: Metaphlan can classify the metagenome from a variety of input data
-          types, including FASTQ files (single-end and paired-end), FASTA, bowtie2-produced
-          SAM files (produced from alignments to the MetaPHlAn marker database) and
-          intermediate bowtie2 alignment files (bowtie2out)
+        description: Metaphlan can classify the metagenome from a variety of input
+          data types, including FASTQ files (single-end and paired-end), FASTA,
+          bowtie2-produced SAM files (produced from alignments to the MetaPHlAn
+          marker database) and intermediate bowtie2 alignment files (bowtie2out)
         pattern: "*.{fastq.gz, fasta, fasta.gz, sam, bowtie2out.txt}"
         ontologies: []
-  - metaphlan_db_latest:
+  - db_metaphlan_latest:
       type: file
       description: |
         Directory containing pre-downloaded and uncompressed MetaPhlAn database downloaded from: http://cmprod1.cibio.unitn.it/biobakery4/metaphlan_databases/.
@@ -50,7 +51,8 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*_profile.txt":
           type: file
-          description: Tab-separated output file of the predicted taxon relative abundances
+          description: Tab-separated output file of the predicted taxon relative
+            abundances
           pattern: "*.{txt}"
           ontologies: []
   biom:
@@ -61,11 +63,11 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.biom":
           type: file
-          description: General-use format for representing biological sample by observation
-            contingency tables
+          description: General-use format for representing biological sample by
+            observation contingency tables
           pattern: "*.{biom}"
           ontologies:
-            - edam: http://edamontology.org/format_3746 # BIOM format
+            - edam: http://edamontology.org/format_3746
   bt2out:
     - - meta:
           type: map
@@ -74,9 +76,9 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.bowtie2out.txt":
           type: file
-          description: Intermediate Bowtie2 output produced from mapping the metagenome
-            against the MetaPHlAn marker database ( not compatible with `bowtie2out`
-            files generated with MetaPhlAn versions below 3 )
+          description: Intermediate Bowtie2 output produced from mapping the
+            metagenome against the MetaPHlAn marker database ( not compatible with
+            `bowtie2out` files generated with MetaPhlAn versions below 3 )
           pattern: "*.{bowtie2out.txt}"
           ontologies: []
   sam:
@@ -87,16 +89,31 @@ output:
             e.g. [ id:'test', single_end:false ]
       - "*.sam":
           type: file
-          description: SAM file produced by MetaPPhlAn of read alignments to MetaPhlAn database gene sequences
+          description: SAM file produced by MetaPPhlAn of read alignments to
+            MetaPhlAn database gene sequences
           pattern: "*.{sam}"
           ontologies: []
+  versions_metaphlan:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - metaphlan:
+          type: string
+          description: The tool name
+      - "metaphlan --version 2>&1 | cut -d ' ' -f 3":
+          type: eval
+          description: The command used to generate the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - metaphlan:
+          type: string
+          description: The tool name
+      - "metaphlan --version 2>&1 | cut -d ' ' -f 3":
+          type: eval
+          description: The command used to generate the version of the tool
 authors:
   - "@MGordon09"
   - "@LilyAnderssonLee"

--- a/modules/nf-core/metaphlan/metaphlan/tests/main.nf.test
+++ b/modules/nf-core/metaphlan/metaphlan/tests/main.nf.test
@@ -47,7 +47,7 @@ nextflow_process {
                         path(process.out.profile[0][1]).readLines()[2..5],
                         path(process.out.biom[0][1]).readLines().last().contains('Biological Observation Matrix'),
                         process.out.bt2out,
-                        process.out.versions
+                        process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 }
             )
@@ -77,7 +77,7 @@ nextflow_process {
                         path(process.out.profile[0][1]).readLines()[2..5],
                         path(process.out.biom[0][1]).readLines().last().contains('Biological Observation Matrix'),
                         process.out.bt2out,
-                        process.out.versions
+                        process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 }
             )
@@ -106,7 +106,7 @@ nextflow_process {
                         path(process.out.profile[0][1]).readLines()[2..5],
                         path(process.out.biom[0][1]).readLines().last().contains('Biological Observation Matrix'),
                         process.out.bt2out,
-                        process.out.versions
+                        process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 }            )
         }
@@ -136,7 +136,7 @@ nextflow_process {
                         path(process.out.biom[0][1]).readLines().last().contains('Biological Observation Matrix'),
                         process.out.bt2out,
                         sam(process.out.sam.get(0).get(1)).getFileType(),
-                        process.out.versions
+                        process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 }
             )
@@ -164,7 +164,7 @@ nextflow_process {
         then {
             assertAll(
                 { assert process.success },
-                { assert snapshot( process.out ).match() }
+                { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
     }

--- a/modules/nf-core/metaphlan/metaphlan/tests/main.nf.test.snap
+++ b/modules/nf-core/metaphlan/metaphlan/tests/main.nf.test.snap
@@ -2,33 +2,6 @@
     "sarscov2 - illumina pair end [fastq] - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test_profile.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.biom:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    
-                ],
-                "3": [
-                    
-                ],
-                "4": [
-                    "versions.yml:md5,db17780c9fc65bc70e9641101c47d0e0"
-                ],
                 "biom": [
                     [
                         {
@@ -39,7 +12,13 @@
                     ]
                 ],
                 "bt2out": [
-                    
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.bowtie2out.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
+                    ]
                 ],
                 "profile": [
                     [
@@ -53,16 +32,20 @@
                 "sam": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,db17780c9fc65bc70e9641101c47d0e0"
+                "versions_metaphlan": [
+                    [
+                        "METAPHLAN_METAPHLAN",
+                        "metaphlan",
+                        "4.1.1"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-09T17:19:58.375514149",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-08-21T08:49:40.627850027"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - illumina pair end [fastq] - save sam": {
         "content": [
@@ -83,15 +66,21 @@
                 ]
             ],
             "SAM",
-            [
-                "versions.yml:md5,db17780c9fc65bc70e9641101c47d0e0"
-            ]
+            {
+                "versions_metaphlan": [
+                    [
+                        "METAPHLAN_METAPHLAN",
+                        "metaphlan",
+                        "4.1.1"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-06-09T17:19:47.219030947",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "25.04.6"
-        },
-        "timestamp": "2025-08-22T07:33:29.981757425"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - illumina single end [fastq]": {
         "content": [
@@ -111,15 +100,21 @@
                     "test.bowtie2out.txt:md5,ef46a9c6a8ce9cae26fbfd5527116fd5"
                 ]
             ],
-            [
-                "versions.yml:md5,db17780c9fc65bc70e9641101c47d0e0"
-            ]
+            {
+                "versions_metaphlan": [
+                    [
+                        "METAPHLAN_METAPHLAN",
+                        "metaphlan",
+                        "4.1.1"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-06-09T17:19:05.401336447",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-27T10:33:32.269571148"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - illumina single end [fasta]": {
         "content": [
@@ -139,15 +134,21 @@
                     "test.bowtie2out.txt:md5,d99d05d6b011c647adf816f10fc6acbe"
                 ]
             ],
-            [
-                "versions.yml:md5,db17780c9fc65bc70e9641101c47d0e0"
-            ]
+            {
+                "versions_metaphlan": [
+                    [
+                        "METAPHLAN_METAPHLAN",
+                        "metaphlan",
+                        "4.1.1"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-06-09T17:19:32.907241155",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-27T10:34:10.262604527"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "sarscov2 - illumina pair end [fastq]": {
         "content": [
@@ -167,14 +168,20 @@
                     "test.bowtie2out.txt:md5,8c1bc21e1d8484b5551bf46331d61bd8"
                 ]
             ],
-            [
-                "versions.yml:md5,db17780c9fc65bc70e9641101c47d0e0"
-            ]
+            {
+                "versions_metaphlan": [
+                    [
+                        "METAPHLAN_METAPHLAN",
+                        "metaphlan",
+                        "4.1.1"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-06-09T17:19:19.166830424",
         "meta": {
-            "nf-test": "0.9.0",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-27T10:33:51.829732777"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/modules/nf-core/minimap2/align/environment.yml
+++ b/modules/nf-core/minimap2/align/environment.yml
@@ -5,5 +5,5 @@ channels:
   - bioconda
 
 dependencies:
-  - bioconda::minimap2=2.29
-  - bioconda::samtools=1.21
+  - bioconda::minimap2=2.30
+  - bioconda::samtools=1.23.1

--- a/modules/nf-core/minimap2/align/main.nf
+++ b/modules/nf-core/minimap2/align/main.nf
@@ -4,9 +4,9 @@ process MINIMAP2_ALIGN {
 
     // Note: the versions here need to match the versions used in the mulled container below and minimap2/index
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/66/66dc96eff11ab80dfd5c044e9b3425f52d818847b9c074794cf0c02bfa781661/data' :
-        'community.wave.seqera.io/library/minimap2_samtools:33bb43c18d22e29c' }"
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
+        'https://community-cr-prod.seqera.io/docker/registry/v2/blobs/sha256/37/37671219cfd244eb9b33db9345d3543ffd83037419a1c57f4648aace493ec2c2/data' :
+        'community.wave.seqera.io/library/minimap2_samtools:b09096fc890429ce' }"
 
     input:
     tuple val(meta), path(reads)
@@ -20,7 +20,7 @@ process MINIMAP2_ALIGN {
     tuple val(meta), path("*.paf")                       , optional: true, emit: paf
     tuple val(meta), path("*.bam")                       , optional: true, emit: bam
     tuple val(meta), path("*.bam.${bam_index_extension}"), optional: true, emit: index
-    path "versions.yml"                                  , emit: versions
+    tuple val("${task.process}"), val("minimap2"), eval("minimap2 --version"), topic: versions, emit: versions_minimap2
 
     when:
     task.ext.when == null || task.ext.when
@@ -38,25 +38,17 @@ process MINIMAP2_ALIGN {
     def bam_input = "${reads.extension}".matches('sam|bam|cram')
     def samtools_reset_fastq = bam_input ? "samtools reset --threads ${task.cpus-1} $args3 $reads | samtools fastq --threads ${task.cpus-1} $args4 |" : ''
     def query = bam_input ? "-" : reads
-    def target = reference ?: (bam_input ? error("BAM input requires reference") : reads)
-
+    def target = reference ?: (bam_input ? error("Error: minimap2/align BAM input mode requires reference") : reads)
     """
     $samtools_reset_fastq \\
     minimap2 \\
-        $args \\
-        -t $task.cpus \\
-        $target \\
-        $query \\
-        $cigar_paf \\
-        $set_cigar_bam \\
-        $bam_output
-
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        minimap2: \$(minimap2 --version 2>&1)
-        samtools: \$(echo \$(samtools --version 2>&1) | sed 's/^.*samtools //; s/Using.*\$//')
-    END_VERSIONS
+        ${args} \\
+        -t ${task.cpus} \\
+        ${target} \\
+        ${query} \\
+        ${cigar_paf} \\
+        ${set_cigar_bam} \\
+        ${bam_output}
     """
 
     stub:
@@ -64,15 +56,11 @@ process MINIMAP2_ALIGN {
     def output_file = bam_format ? "${prefix}.bam" : "${prefix}.paf"
     def bam_index = bam_index_extension ? "touch ${prefix}.bam.${bam_index_extension}" : ""
     def bam_input = "${reads.extension}".matches('sam|bam|cram')
-    def target = reference ?: (bam_input ? error("BAM input requires reference") : reads)
-
+    if(bam_input && !reference) {
+        error("Error: minimap2/align BAM input mode requires reference!")
+	}
     """
     touch $output_file
     ${bam_index}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        minimap2: \$(minimap2 --version 2>&1)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/minimap2/align/meta.yml
+++ b/modules/nf-core/minimap2/align/meta.yml
@@ -85,13 +85,27 @@ output:
           description: BAM alignment index
           pattern: "*.bam.*"
           ontologies: []
+  versions_minimap2:
+    - - ${task.process}:
+          type: string
+          description: The process name
+      - minimap2:
+          type: string
+          description: The tool name
+      - minimap2 --version:
+          type: eval
+          description: The tool version
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: The process name
+      - minimap2:
+          type: string
+          description: The tool name
+      - minimap2 --version:
+          type: eval
+          description: The tool version
 authors:
   - "@heuermh"
   - "@sofstam"

--- a/modules/nf-core/minimap2/align/tests/main.nf.test
+++ b/modules/nf-core/minimap2/align/tests/main.nf.test
@@ -36,7 +36,7 @@ nextflow_process {
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -71,7 +71,7 @@ nextflow_process {
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
                     file(process.out.index[0][1]).name,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -108,7 +108,7 @@ nextflow_process {
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -142,7 +142,7 @@ nextflow_process {
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -176,7 +176,7 @@ nextflow_process {
                 { assert snapshot(
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }
@@ -211,7 +211,7 @@ nextflow_process {
                     bam(process.out.bam[0][1]).getHeader(),
                     bam(process.out.bam[0][1]).getReadsMD5(),
                     file(process.out.index[0][1]).name,
-                    process.out.versions
+                    process.out.findAll { key, val -> key.startsWith("versions_") }
                 ).match() }
             )
         }

--- a/modules/nf-core/minimap2/align/tests/main.nf.test.snap
+++ b/modules/nf-core/minimap2/align/tests/main.nf.test.snap
@@ -4,20 +4,26 @@
             [
                 "@HD\tVN:1.6\tSO:coordinate",
                 "@SQ\tSN:MT192765.1\tLN:29829",
-                "@PG\tID:minimap2\tPN:minimap2\tVN:2.29-r1283\tCL:minimap2 -t 2 -a genome.fasta -",
-                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam##idx##test.bam.bai --write-index"
+                "@PG\tID:minimap2\tPN:minimap2\tVN:2.30-r1287\tCL:minimap2 -t 2 -a genome.fasta -",
+                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.23.1\tCL:samtools sort -@ 1 -o test.bam##idx##test.bam.bai --write-index"
             ],
             "5d426b9a5f5b2c54f1d7f1e4c238ae94",
             "test.bam.bai",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-04-23T17:26:01.315588",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:23.829797899"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - bam, fasta, true, 'bai', false, false - stub": {
         "content": [
@@ -44,7 +50,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ],
                 "bam": [
                     [
@@ -67,16 +77,20 @@
                 "paf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-23T17:26:29.211025",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:54.665655242"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - fastq, fasta, true, 'bai', false, false - stub": {
         "content": [
@@ -103,7 +117,11 @@
                     ]
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ],
                 "bam": [
                     [
@@ -126,16 +144,20 @@
                 "paf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-23T17:26:14.56423",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:38.492212433"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - fastq, fasta, false, [], false, false - stub": {
         "content": [
@@ -156,7 +178,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ],
                 "bam": [
                     
@@ -173,16 +199,20 @@
                         "test.paf:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-23T17:26:19.467028",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:43.879647142"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - fastq, fasta, true, [], false, false - stub": {
         "content": [
@@ -203,7 +233,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ],
                 "bam": [
                     [
@@ -220,93 +254,121 @@
                 "paf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-23T17:26:10.208287",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:33.262333471"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - [fastq1, fastq2], fasta, true, false, false": {
         "content": [
             [
                 "@HD\tVN:1.6\tSO:coordinate",
                 "@SQ\tSN:MT192765.1\tLN:29829",
-                "@PG\tID:minimap2\tPN:minimap2\tVN:2.29-r1283\tCL:minimap2 -t 2 -a genome.fasta test_1.fastq.gz test_2.fastq.gz",
-                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam"
+                "@PG\tID:minimap2\tPN:minimap2\tVN:2.30-r1287\tCL:minimap2 -t 2 -a genome.fasta test_1.fastq.gz test_2.fastq.gz",
+                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.23.1\tCL:samtools sort -@ 1 -o test.bam"
             ],
             "1bc392244f228bf52cf0b5a8f6a654c9",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-04-23T17:25:45.435644",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:07.571731983"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - fastq, fasta, true, [], false, false": {
         "content": [
             [
                 "@HD\tVN:1.6\tSO:coordinate",
                 "@SQ\tSN:MT192765.1\tLN:29829",
-                "@PG\tID:minimap2\tPN:minimap2\tVN:2.29-r1283\tCL:minimap2 -t 2 -a genome.fasta test_1.fastq.gz",
-                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam"
+                "@PG\tID:minimap2\tPN:minimap2\tVN:2.30-r1287\tCL:minimap2 -t 2 -a genome.fasta test_1.fastq.gz",
+                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.23.1\tCL:samtools sort -@ 1 -o test.bam"
             ],
             "f194745c0ccfcb2a9c0aee094a08750",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-04-23T17:25:35.537045",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:47:56.497792473"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - fastq, fasta, true, 'bai', false, false": {
         "content": [
             [
                 "@HD\tVN:1.6\tSO:coordinate",
                 "@SQ\tSN:MT192765.1\tLN:29829",
-                "@PG\tID:minimap2\tPN:minimap2\tVN:2.29-r1283\tCL:minimap2 -t 2 -a genome.fasta test_1.fastq.gz",
-                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam##idx##test.bam.bai --write-index"
+                "@PG\tID:minimap2\tPN:minimap2\tVN:2.30-r1287\tCL:minimap2 -t 2 -a genome.fasta test_1.fastq.gz",
+                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.23.1\tCL:samtools sort -@ 1 -o test.bam##idx##test.bam.bai --write-index"
             ],
             "f194745c0ccfcb2a9c0aee094a08750",
             "test.bam.bai",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-04-23T17:25:40.308055",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:01.888544427"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - bam, fasta, true, [], false, false": {
         "content": [
             [
                 "@HD\tVN:1.6\tSO:coordinate",
                 "@SQ\tSN:MT192765.1\tLN:29829",
-                "@PG\tID:minimap2\tPN:minimap2\tVN:2.29-r1283\tCL:minimap2 -t 2 -a genome.fasta -",
-                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam"
+                "@PG\tID:minimap2\tPN:minimap2\tVN:2.30-r1287\tCL:minimap2 -t 2 -a genome.fasta -",
+                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.23.1\tCL:samtools sort -@ 1 -o test.bam"
             ],
             "5d426b9a5f5b2c54f1d7f1e4c238ae94",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-04-23T17:25:55.526019",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:18.376062313"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - bam, fasta, true, [], false, false - stub": {
         "content": [
@@ -327,7 +389,11 @@
                     
                 ],
                 "3": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ],
                 "bam": [
                     [
@@ -344,16 +410,20 @@
                 "paf": [
                     
                 ],
-                "versions": [
-                    "versions.yml:md5,231f31609e2b72661af6a11b7aee3cfe"
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-04-23T17:26:24.507384",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:49.268693724"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     },
     "sarscov2 - fastq, [], true, false, false": {
         "content": [
@@ -459,18 +529,24 @@
                 "@SQ\tSN:ERR5069949.3258358\tLN:151",
                 "@SQ\tSN:ERR5069949.1476386\tLN:151",
                 "@SQ\tSN:ERR5069949.2415814\tLN:150",
-                "@PG\tID:minimap2\tPN:minimap2\tVN:2.29-r1283\tCL:minimap2 -t 2 -a test_1.fastq.gz test_1.fastq.gz",
-                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.21\tCL:samtools sort -@ 1 -o test.bam"
+                "@PG\tID:minimap2\tPN:minimap2\tVN:2.30-r1287\tCL:minimap2 -t 2 -a test_1.fastq.gz test_1.fastq.gz",
+                "@PG\tID:samtools\tPN:samtools\tPP:minimap2\tVN:1.23.1\tCL:samtools sort -@ 1 -o test.bam"
             ],
             "16c1c651f8ec67383bcdee3c55aed94f",
-            [
-                "versions.yml:md5,660fcf8ff66d4dce2045ffa0e325eed8"
-            ]
+            {
+                "versions_minimap2": [
+                    [
+                        "MINIMAP2_ALIGN",
+                        "minimap2",
+                        "2.30-r1287"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-04-23T17:25:49.904205",
         "meta": {
-            "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
-        },
-        "timestamp": "2025-04-22T14:48:12.942360555"
+            "nf-test": "0.9.5",
+            "nextflow": "25.04.2"
+        }
     }
 }

--- a/modules/nf-core/nanoq/main.nf
+++ b/modules/nf-core/nanoq/main.nf
@@ -3,9 +3,9 @@ process NANOQ {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
         ? 'https://depot.galaxyproject.org/singularity/nanoq:0.10.0--h031d066_2'
-        : 'biocontainers/nanoq:0.10.0--h031d066_2'}"
+        : 'quay.io/biocontainers/nanoq:0.10.0--h031d066_2'}"
 
     input:
     tuple val(meta), path(ontreads)
@@ -14,7 +14,7 @@ process NANOQ {
     output:
     tuple val(meta), path("*.{stats,json}")            , emit: stats
     tuple val(meta), path("${prefix}.${output_format}"), emit: reads
-    path "versions.yml"                                , emit: versions
+    tuple val("${task.process}"), val('nanoq'), eval("nanoq --version | sed -e 's/nanoq //g'"), topic: versions, emit: versions_nanoq
 
     when:
     task.ext.when == null || task.ext.when
@@ -27,23 +27,12 @@ process NANOQ {
         ${args} \\
         -r ${prefix}.stats \\
         -o ${prefix}.${output_format}
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nanoq: \$(nanoq --version | sed -e 's/nanoq //g')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     prefix = task.ext.prefix ?: "${meta.id}_filtered"
     """
     echo "" | gzip > ${prefix}.${output_format}
     touch ${prefix}.stats
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nanoq: \$(nanoq --version | sed -e 's/nanoq //g')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/nanoq/meta.yml
+++ b/modules/nf-core/nanoq/meta.yml
@@ -58,13 +58,27 @@ output:
           pattern: "*.{fasta,fastq}{,.gz,.bz2,.lzma}"
           ontologies:
             - edam: http://edamontology.org/format_1930 # FASTQ
+  versions_nanoq:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - nanoq:
+          type: string
+          description: The tool name
+      - "nanoq --version | sed -e 's/nanoq //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - "${task.process}":
+          type: string
+          description: The name of the process
+      - nanoq:
+          type: string
+          description: The name of the tool
+      - "nanoq --version | sed -e 's/nanoq //g'":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@LilyAnderssonLee"
 maintainers:

--- a/modules/nf-core/nanoq/tests/main.nf.test.snap
+++ b/modules/nf-core/nanoq/tests/main.nf.test.snap
@@ -21,7 +21,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ],
                 "reads": [
                     [
@@ -41,16 +45,20 @@
                         "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                "versions_nanoq": [
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-08T12:28:22.535750765",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-07-11T11:39:32.117229"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - nanopore_compressed_gz - stub": {
         "content": [
@@ -74,7 +82,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ],
                 "reads": [
                     [
@@ -94,16 +106,20 @@
                         "test_filtered.stats:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                "versions_nanoq": [
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-08T12:28:34.579863224",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-07-11T11:42:06.039307"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - nanopore_compressed_bz2": {
         "content": [
@@ -127,7 +143,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ],
                 "reads": [
                     [
@@ -147,16 +167,20 @@
                         "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                "versions_nanoq": [
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-08T12:28:26.617329659",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-07-11T11:39:36.674647"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - nanopore_compressed_lzma": {
         "content": [
@@ -180,7 +204,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ],
                 "reads": [
                     [
@@ -200,16 +228,20 @@
                         "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                "versions_nanoq": [
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-08T12:28:30.663616728",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-07-11T11:39:41.51344"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     },
     "sarscov2 - nanopore_uncompressed": {
         "content": [
@@ -233,7 +265,11 @@
                     ]
                 ],
                 "2": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ],
                 "reads": [
                     [
@@ -253,15 +289,19 @@
                         "test_filtered.stats:md5,5ab32af3352dfeca8268e10edf6e4dbe"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7a40efe417ff7dbb9e91e9c1629a04e6"
+                "versions_nanoq": [
+                    [
+                        "NANOQ",
+                        "nanoq",
+                        "0.10.0"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-03-08T12:28:18.491797605",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "23.04.1"
-        },
-        "timestamp": "2024-07-11T11:39:26.868897"
+            "nf-test": "0.9.4",
+            "nextflow": "25.10.4"
+        }
     }
 }

--- a/modules/nf-core/nonpareil/curve/main.nf
+++ b/modules/nf-core/nonpareil/curve/main.nf
@@ -3,16 +3,16 @@ process NONPAREIL_CURVE {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/nonpareil:3.5.5--r43hdcf5f25_0':
-        'biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
+        'quay.io/biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
 
     input:
     tuple val(meta), path(npo)
 
     output:
     tuple val(meta), path("*.png"), optional: true, emit: png
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('Nonpareil'), eval('Rscript -e "library(Nonpareil); cat(paste(unlist(packageVersion(\'Nonpareil\')), collapse = \'.\'))"'), emit: versions_nonpareil, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,30 +22,17 @@ process NONPAREIL_CURVE {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args_cmd = args != '' ? ", ${args}" : ""
     """
-    #!/usr/bin/env Rscript
+    Rscript - <<EOF
     library(Nonpareil)
-
     png(file='${prefix}.png')
     Nonpareil.curve('${npo}'${args_cmd})
     dev.off()
-
-    version_file_path <- "versions.yml"
-    version_nonpareil <- paste(unlist(packageVersion("Nonpareil")), collapse = ".")
-    f <- file(version_file_path, "w")
-    writeLines('"${task.process}":', f)
-    writeLines("    nonpareil: ", f, sep = "")
-    writeLines(version_nonpareil, f)
-    close(f)
+    EOF
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.png
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}": \$(Rscript -e 'library('Nonpareil'); cat(paste(unlist(packageVersion("Nonpareil")),collapse="."))')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/nonpareil/curve/meta.yml
+++ b/modules/nf-core/nonpareil/curve/meta.yml
@@ -1,7 +1,6 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/nf-core/modules/master/modules/yaml-schema.json
 name: "nonpareil_curve"
-description: Visualise metagenome redundancy curve in PNG format from a single Nonpareil
-  npo file
+description: Visualise metagenome redundancy curve in PNG format from a single
+  Nonpareil npo file
 keywords:
   - metagenomics
   - statistics
@@ -17,7 +16,8 @@ tools:
       documentation: "https://nonpareil.readthedocs.io/en/latest/"
       tool_dev_url: "https://github.com/lmrodriguezr/nonpareil"
       doi: "10.1128/msystems.00039-"
-      licence: ["Artistic License 2.0"]
+      licence:
+        - "Artistic License 2.0"
       identifier: biotools:nonpareil
 input:
   - - meta:
@@ -42,13 +42,27 @@ output:
           description: PNG file of the Nonpareil curve
           pattern: "*.png"
           ontologies: []
+  versions_nonpareil:
+    - - ${task.process}:
+          type: string
+          description: Process which generated the version
+      - Nonpareil:
+          type: string
+          description: Tool name
+      - Rscript -e "library(Nonpareil); cat(paste(unlist(packageVersion('Nonpareil')), collapse = '.'))":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: Process which generated the version
+      - Nonpareil:
+          type: string
+          description: Tool name
+      - Rscript -e "library(Nonpareil); cat(paste(unlist(packageVersion('Nonpareil')), collapse = '.'))":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/nonpareil/curve/tests/main.nf.test
+++ b/modules/nf-core/nonpareil/curve/tests/main.nf.test
@@ -37,12 +37,10 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
                 { assert snapshot(
-                    process.out.versions,
-                    file(process.out.png[0][1]).name,
-                    ).match()
+                    sanitizeOutput(process.out, unstableKeys: ["png"])).match()
                 }
             )
         }
@@ -54,9 +52,6 @@ nextflow_process {
         options "-stub"
 
         when {
-            params {
-                outdir = "$outputDir"
-            }
             process {
                 """
                 input[0] = NONPAREIL_NONPAREIL.out.npo
@@ -65,9 +60,9 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-            { assert process.success },
-            { assert snapshot(process.out).match() }
+            { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/nonpareil/curve/tests/main.nf.test.snap
+++ b/modules/nf-core/nonpareil/curve/tests/main.nf.test.snap
@@ -1,32 +1,34 @@
 {
     "candidatus_portiera_aleyrodidarum": {
         "content": [
-            [
-                "versions.yml:md5,591a0a74569106b79c101d0059a822ad"
-            ],
-            "test.png"
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-07T12:11:37.549218924"
-    },
-    "candidatus_portiera_aleyrodidarum - stub": {
-        "content": [
             {
-                "0": [
+                "png": [
                     [
                         {
                             "id": "test",
                             "single_end": false
                         },
-                        "test.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.png"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,ea8a60928f2d6fb3fe8895b63fba42f4"
-                ],
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_CURVE",
+                        "Nonpareil",
+                        "3.5.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-11T10:03:49.643043066",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "candidatus_portiera_aleyrodidarum - stub": {
+        "content": [
+            {
                 "png": [
                     [
                         {
@@ -36,15 +38,19 @@
                         "test.png:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,ea8a60928f2d6fb3fe8895b63fba42f4"
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_CURVE",
+                        "Nonpareil",
+                        "3.5.3"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-11T09:30:38.269784162",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-07T14:32:21.066752297"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/modules/nf-core/nonpareil/nonpareil/main.nf
+++ b/modules/nf-core/nonpareil/nonpareil/main.nf
@@ -3,9 +3,9 @@ process NONPAREIL_NONPAREIL {
     label 'process_low'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/nonpareil:3.5.5--r43hdcf5f25_0':
-        'biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
+        'quay.io/biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
 
     input:
     tuple val(meta), path(reads)
@@ -17,7 +17,7 @@ process NONPAREIL_NONPAREIL {
     tuple val(meta), path("*.npc"), emit: npc
     tuple val(meta), path("*.npl"), emit: npl
     tuple val(meta), path("*.npo"), emit: npo
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('nonpareil'), eval('nonpareil -V 2>&1 | sed "s/Nonpareil v//"'), emit: versions_nonpareil, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -35,25 +35,14 @@ process NONPAREIL_NONPAREIL {
         -R ${mem_mb} \\
         -b $prefix \\
         $args
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nonpareil: \$(echo \$(nonpareil -V 2>&1) | sed 's/Nonpareil v//' )
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.npa
     touch ${prefix}.npc
     touch ${prefix}.npl
     touch ${prefix}.npo
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nonpareil: \$(echo \$(nonpareil -V 2>&1) | sed 's/Nonpareil v//' )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/nonpareil/nonpareil/meta.yml
+++ b/modules/nf-core/nonpareil/nonpareil/meta.yml
@@ -82,13 +82,27 @@ output:
           description: Redundancy summary file
           pattern: "*.npo"
           ontologies: []
+  versions_nonpareil:
+    - - ${task.process}:
+          type: string
+          description: Process which generated the version
+      - nonpareil:
+          type: string
+          description: Tool name
+      - nonpareil -V 2>&1 | sed "s/Nonpareil v//":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: Process which generated the version
+      - nonpareil:
+          type: string
+          description: Tool name
+      - nonpareil -V 2>&1 | sed "s/Nonpareil v//":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/nonpareil/nonpareil/tests/main.nf.test
+++ b/modules/nf-core/nonpareil/nonpareil/tests/main.nf.test
@@ -26,14 +26,14 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
                 { assert snapshot(
                         file(process.out.npa[0][1]).name,
                         file(process.out.npc[0][1]).name,
                         path(process.out.npo[0][1]).readLines()[0],
-                        path(process.out.npl[0][1]).readLines().last().contains("Everything seems correct"),
-                        process.out.versions
+                            path(process.out.npl[0][1]).readLines().last().contains("Everything seems correct"),
+                            sanitizeOutput(process.out, unstableKeys: ["npa", "npc", "npo", "npl"])
                     ).match()
                 }
             )
@@ -69,14 +69,14 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
                 { assert snapshot(
                         file(process.out.npa[0][1]).name,
                         file(process.out.npc[0][1]).name,
                         path(process.out.npo[0][1]).readLines()[0],
                         path(process.out.npl[0][1]).readLines().last().contains("Everything seems correct"),
-                        process.out.versions
+                        sanitizeOutput(process.out, unstableKeys: ["npa", "npc", "npo", "npl"])
                     ).match()
                 }
             )
@@ -102,9 +102,9 @@ test("candidatus_portiera_aleyrodidarum - stub") {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert snapshot(process.out).match() }
+            { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/nonpareil/nonpareil/tests/main.nf.test.snap
+++ b/modules/nf-core/nonpareil/nonpareil/tests/main.nf.test.snap
@@ -5,15 +5,57 @@
             "test.npc",
             "# @impl: Nonpareil",
             true,
-            [
-                "versions.yml:md5,5a5e1b70e05a4637015adbfaeac017fd"
-            ]
+            {
+                "npa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npa"
+                    ]
+                ],
+                "npc": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npc"
+                    ]
+                ],
+                "npl": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npl"
+                    ]
+                ],
+                "npo": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npo"
+                    ]
+                ],
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_NONPAREIL",
+                        "nonpareil",
+                        "3.5.5"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-06-11T12:22:52.214824444",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-07T14:11:57.001694911"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "candidatus_portiera_aleyrodidarum - gzipped": {
         "content": [
@@ -21,58 +63,61 @@
             "test.npc",
             "# @impl: Nonpareil",
             true,
-            [
-                "versions.yml:md5,5a5e1b70e05a4637015adbfaeac017fd"
-            ]
+            {
+                "npa": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npa"
+                    ]
+                ],
+                "npc": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npc"
+                    ]
+                ],
+                "npl": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npl"
+                    ]
+                ],
+                "npo": [
+                    [
+                        {
+                            "id": "test",
+                            "single_end": false
+                        },
+                        "test.npo"
+                    ]
+                ],
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_NONPAREIL",
+                        "nonpareil",
+                        "3.5.5"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-06-11T12:22:43.743388929",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-07T14:11:49.888813434"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "candidatus_portiera_aleyrodidarum - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.npa:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.npc:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.npl:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test",
-                            "single_end": false
-                        },
-                        "test.npo:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    "versions.yml:md5,5a5e1b70e05a4637015adbfaeac017fd"
-                ],
                 "npa": [
                     [
                         {
@@ -109,15 +154,19 @@
                         "test.npo:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,5a5e1b70e05a4637015adbfaeac017fd"
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_NONPAREIL",
+                        "nonpareil",
+                        "3.5.5"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-11T05:52:14.358983255",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-07T14:38:09.784957219"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/modules/nf-core/nonpareil/nonpareil/tests/nextflow.config
+++ b/modules/nf-core/nonpareil/nonpareil/tests/nextflow.config
@@ -1,7 +1,5 @@
 process {
 
-    publishDir = { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" }
-
     withName: NONPAREIL_NONPAREIL {
         ext.args = '-X 100'
     }

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/main.nf
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/main.nf
@@ -3,9 +3,9 @@ process NONPAREIL_NONPAREILCURVESR {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/nonpareil:3.5.5--r43hdcf5f25_0':
-        'biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
+        'quay.io/biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
 
     input:
     tuple val(meta), path(npos)
@@ -16,7 +16,7 @@ process NONPAREIL_NONPAREILCURVESR {
     tuple val(meta), path("*.csv" ), emit: csv , optional: true
     tuple val(meta), path("*.pdf" ), emit: pdf , optional: true
 
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('nonpareil'), eval('nonpareil -V 2>&1 | sed "s/Nonpareil v//"'), emit: versions_nonpareil, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -33,25 +33,14 @@ process NONPAREIL_NONPAREILCURVESR {
         --csv ${prefix}.csv \\
         --pdf ${prefix}.pdf \\
         $npos
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nonpareil: \$(echo \$(nonpareil -V 2>&1) | sed 's/Nonpareil v//' )
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.json
     touch ${prefix}.tsv
     touch ${prefix}.csv
     touch ${prefix}.pdf
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        nonpareil: \$(echo \$(nonpareil -V 2>&1) | sed 's/Nonpareil v//' )
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/meta.yml
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/meta.yml
@@ -51,28 +51,57 @@ output:
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*.tsv": {}
+      - "*.tsv":
+          type: file
+          description: Nonpareil summary data in TSV format
+          pattern: "*.tsv"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
   csv:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*.csv": {}
+      - "*.csv":
+          type: file
+          description: Nonpareil summary data in CSV format
+          pattern: "*.csv"
+          ontologies:
+            - edam: http://edamontology.org/format_3752 # CSV
   pdf:
     - - meta:
           type: map
           description: |
             Groovy Map containing sample information
             e.g. `[ id:'sample1', single_end:false ]`
-      - "*.pdf": {}
+      - "*.pdf":
+          type: file
+          description: Nonpareil curves plot in PDF format
+          pattern: "*.pdf"
+          ontologies:
+            - edam: http://edamontology.org/format_3508 # PDF
+  versions_nonpareil:
+    - - ${task.process}:
+          type: string
+          description: Process which generated the version
+      - nonpareil:
+          type: string
+          description: Tool name
+      - nonpareil -V 2>&1 | sed "s/Nonpareil v//":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: Process which generated the version
+      - nonpareil:
+          type: string
+          description: Tool name
+      - nonpareil -V 2>&1 | sed "s/Nonpareil v//":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/tests/main.nf.test
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/tests/main.nf.test
@@ -37,14 +37,14 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
                 { assert snapshot(
                         path(process.out.json[0][1]).text.contains("modelR\": 0."),
-                        path(process.out.tsv[0][1]).text.contains("test	0."),
+                        path(process.out.tsv[0][1]).text.contains("test\t0."),
                         path(process.out.csv[0][1]).text.contains("test\",0."),
                         file(process.out.pdf[0][1]).name,
-                        process.out.versions
+                        process.out.findAll { key, val -> key.startsWith('versions') }
                     ).match()
                 }
             )
@@ -65,9 +65,9 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert snapshot(process.out).match() }
+            { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/nonpareil/nonpareilcurvesr/tests/main.nf.test.snap
+++ b/modules/nf-core/nonpareil/nonpareilcurvesr/tests/main.nf.test.snap
@@ -5,54 +5,25 @@
             true,
             true,
             "test.pdf",
-            [
-                "versions.yml:md5,9aae4700a1ceafa37850be8d82d8d6dc"
-            ]
+            {
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_NONPAREILCURVESR",
+                        "nonpareil",
+                        "3.5.5"
+                    ]
+                ]
+            }
         ],
+        "timestamp": "2026-06-11T05:56:36.433707732",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-08T12:14:04.694169651"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     },
     "candidatus_portiera_aleyrodidarum - stub": {
         "content": [
             {
-                "0": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.json:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "1": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "2": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.csv:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "3": [
-                    [
-                        {
-                            "id": "test"
-                        },
-                        "test.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
-                ],
-                "4": [
-                    "versions.yml:md5,9aae4700a1ceafa37850be8d82d8d6dc"
-                ],
                 "csv": [
                     [
                         {
@@ -85,15 +56,19 @@
                         "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,9aae4700a1ceafa37850be8d82d8d6dc"
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_NONPAREILCURVESR",
+                        "nonpareil",
+                        "3.5.5"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-11T05:52:41.774271012",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-08T12:03:11.519050978"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/modules/nf-core/nonpareil/set/main.nf
+++ b/modules/nf-core/nonpareil/set/main.nf
@@ -3,16 +3,16 @@ process NONPAREIL_SET {
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+    container "${ workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container ?
         'https://depot.galaxyproject.org/singularity/nonpareil:3.5.5--r43hdcf5f25_0':
-        'biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
+        'quay.io/biocontainers/nonpareil:3.5.5--r43hdcf5f25_0' }"
 
     input:
     tuple val(meta), path(npos)
 
     output:
     tuple val(meta), path("*.png"), emit: png
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('Nonpareil'), eval('Rscript -e "library(Nonpareil); cat(paste(unlist(packageVersion(\'Nonpareil\')), collapse = \'.\'))"'), emit: versions_nonpareil, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -22,30 +22,17 @@ process NONPAREIL_SET {
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args_cmd = args != '' ? ", ${args}" : ""
     """
-    #!/usr/bin/env Rscript
+    Rscript - <<EOF
     library(Nonpareil)
-
     png(file='${prefix}.png')
     Nonpareil.set(list.files(pattern='*.npo')${args_cmd})
     dev.off()
-
-    version_file_path <- "versions.yml"
-    version_nonpareil <- paste(unlist(packageVersion("Nonpareil")), collapse = ".")
-    f <- file(version_file_path, "w")
-    writeLines('"${task.process}":', f)
-    writeLines("    nonpareil: ", f, sep = "")
-    writeLines(version_nonpareil, f)
-    close(f)
+    EOF
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     touch ${prefix}.png
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}": \$(Rscript -e 'library('Nonpareil'); cat(paste(unlist(packageVersion("Nonpareil")),collapse="."))')
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/nonpareil/set/meta.yml
+++ b/modules/nf-core/nonpareil/set/meta.yml
@@ -42,13 +42,27 @@ output:
           description: PNG file of all the Nonpareil curves of the input npo files
           pattern: "*.png"
           ontologies: []
+  versions_nonpareil:
+    - - ${task.process}:
+          type: string
+          description: Process which generated the version
+      - Nonpareil:
+          type: string
+          description: Tool name
+      - Rscript -e "library(Nonpareil); cat(paste(unlist(packageVersion('Nonpareil')), collapse = '.'))":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
   versions:
-    - versions.yml:
-        type: file
-        description: File containing software versions
-        pattern: "versions.yml"
-        ontologies:
-          - edam: http://edamontology.org/format_3750 # YAML
+    - - ${task.process}:
+          type: string
+          description: Process which generated the version
+      - Nonpareil:
+          type: string
+          description: Tool name
+      - Rscript -e "library(Nonpareil); cat(paste(unlist(packageVersion('Nonpareil')), collapse = '.'))":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jfy133"
 maintainers:

--- a/modules/nf-core/nonpareil/set/tests/main.nf.test
+++ b/modules/nf-core/nonpareil/set/tests/main.nf.test
@@ -37,13 +37,9 @@ nextflow_process {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert snapshot(
-                        file(process.out.png[0][1]).name,
-                        process.out.versions
-                    ).match()
-                }
+                { assert snapshot(sanitizeOutput(process.out, unstableKeys: ["png"])).match() }
             )
         }
 
@@ -62,9 +58,9 @@ test("candidatus_portiera_aleyrodidarum - stub") {
         }
 
         then {
+            assert process.success
             assertAll(
-                { assert process.success },
-                { assert snapshot(process.out).match() }
+            { assert snapshot(sanitizeOutput(process.out)).match() }
             )
         }
 

--- a/modules/nf-core/nonpareil/set/tests/main.nf.test.snap
+++ b/modules/nf-core/nonpareil/set/tests/main.nf.test.snap
@@ -1,31 +1,33 @@
 {
     "candidatus_portiera_aleyrodidarum": {
         "content": [
-            "test.png",
-            [
-                "versions.yml:md5,99b7abbea8d46b0a3d15ecd35049dc8d"
-            ]
-        ],
-        "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-07T12:12:45.998873423"
-    },
-    "candidatus_portiera_aleyrodidarum - stub": {
-        "content": [
             {
-                "0": [
+                "png": [
                     [
                         {
                             "id": "test"
                         },
-                        "test.png:md5,d41d8cd98f00b204e9800998ecf8427e"
+                        "test.png"
                     ]
                 ],
-                "1": [
-                    "versions.yml:md5,e12f68cd2102c6ab64e888bec3c7e7aa"
-                ],
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_SET",
+                        "Nonpareil",
+                        "3.5.3"
+                    ]
+                ]
+            }
+        ],
+        "timestamp": "2026-06-11T05:47:38.49303143",
+        "meta": {
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
+    },
+    "candidatus_portiera_aleyrodidarum - stub": {
+        "content": [
+            {
                 "png": [
                     [
                         {
@@ -34,15 +36,19 @@
                         "test.png:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,e12f68cd2102c6ab64e888bec3c7e7aa"
+                "versions_nonpareil": [
+                    [
+                        "NONPAREIL_SET",
+                        "Nonpareil",
+                        "3.5.3"
+                    ]
                 ]
             }
         ],
+        "timestamp": "2026-06-11T05:47:46.543089033",
         "meta": {
-            "nf-test": "0.8.4",
-            "nextflow": "24.04.4"
-        },
-        "timestamp": "2024-08-07T14:40:53.480864245"
+            "nf-test": "0.9.5",
+            "nextflow": "26.04.0"
+        }
     }
 }

--- a/modules/nf-core/porechop/abi/environment.yml
+++ b/modules/nf-core/porechop/abi/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::porechop_abi=0.5.0
+  - bioconda::porechop_abi=0.5.0post1

--- a/modules/nf-core/porechop/abi/main.nf
+++ b/modules/nf-core/porechop/abi/main.nf
@@ -1,20 +1,20 @@
 process PORECHOP_ABI {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_medium'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/porechop_abi:0.5.0--py310h590eda1_0':
-        'biocontainers/porechop_abi:0.5.0--py310h590eda1_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/porechop_abi:0.5.0post1--py310h275bdba_0'
+        : 'quay.io/biocontainers/porechop_abi:0.5.0post1--py310h275bdba_0'}"
 
     input:
     tuple val(meta), path(reads)
     path custom_adapters
 
     output:
-    tuple val(meta), path("*.fastq.gz") , emit: reads
-    tuple val(meta), path("*.log")      , emit: log
-    path "versions.yml"                 , emit: versions
+    tuple val(meta), path("*.fastq.gz"), emit: reads
+    tuple val(meta), path("*.log"), emit: log
+    path "versions.yml", emit: versions
 
     when:
     task.ext.when == null || task.ext.when
@@ -23,13 +23,15 @@ process PORECHOP_ABI {
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}.porechop_abi"
     def adapters_list = custom_adapters ? "--custom_adapters ${custom_adapters}" : ""
-    if ("$reads" == "${prefix}.fastq.gz") error "Input and output names are the same, use \"task.ext.prefix\" to disambiguate!"
+    if ("${reads}" == "${prefix}.fastq.gz") {
+        error("Input and output names are the same, use \"task.ext.prefix\" to disambiguate!")
+    }
     """
     porechop_abi \\
-        --input $reads \\
-        $adapters_list \\
-        --threads $task.cpus \\
-        $args \\
+        --input ${reads} \\
+        ${adapters_list} \\
+        --threads ${task.cpus} \\
+        ${args} \\
         --output ${prefix}.fastq.gz \\
         | tee ${prefix}.log
     cat <<-END_VERSIONS > versions.yml
@@ -39,9 +41,7 @@ process PORECHOP_ABI {
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}.porechop_abi"
-    def adapters_list = custom_adapters ? "--custom_adapters ${custom_adapters}" : ""
     """
     echo "" | gzip > ${prefix}.fastq.gz
     touch ${prefix}.log

--- a/modules/nf-core/porechop/abi/meta.yml
+++ b/modules/nf-core/porechop/abi/meta.yml
@@ -25,13 +25,16 @@ input:
         type: file
         description: fastq/fastq.gz file
         pattern: "*.{fastq,fastq.gz,fq,fq.gz}"
-  - - custom_adapters:
-        type: file
-        description: Text file containing custom adapters
+        ontologies:
+          - edam: http://edamontology.org/format_1930 # FASTQ
+  - custom_adapters:
+      type: file
+      description: Text file containing custom adapters
 
+      ontologies: []
 output:
-  - reads:
-      - meta:
+  reads:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -40,8 +43,10 @@ output:
           type: file
           description: Adapter-trimmed fastq.gz file
           pattern: "*.fastq.gz"
-  - log:
-      - meta:
+          ontologies:
+            - edam: http://edamontology.org/format_3989 # GZIP format
+  log:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -50,11 +55,14 @@ output:
           type: file
           description: Log file containing stdout information
           pattern: "*.log"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies: []
+  versions:
+    - versions.yml:
+        type: file
+        description: File containing software versions
+        pattern: "versions.yml"
+        ontologies:
+          - edam: http://edamontology.org/format_3750 # YAML
 authors:
   - "@sofstam"
   - "LilyAnderssonLee"

--- a/modules/nf-core/sylph/profile/environment.yml
+++ b/modules/nf-core/sylph/profile/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - bioconda::sylph=0.7.0
+  - bioconda::sylph=0.9.0

--- a/modules/nf-core/sylph/profile/main.nf
+++ b/modules/nf-core/sylph/profile/main.nf
@@ -1,19 +1,19 @@
 process SYLPH_PROFILE {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_high'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sylph:0.7.0--h919a2d8_0' :
-        'biocontainers/sylph:0.7.0--h919a2d8_0' }"
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/sylph:0.9.0--ha6fb395_0'
+        : 'quay.io/biocontainers/sylph:0.9.0--ha6fb395_0'}"
 
     input:
     tuple val(meta), path(reads)
-    path(database)
+    path database
 
     output:
     tuple val(meta), path('*.tsv'), emit: profile_out
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('sylph'), eval('sylph -V | sed "s/sylph //g"'), topic: versions, emit: versions_sylph
 
     when:
     task.ext.when == null || task.ext.when
@@ -21,31 +21,19 @@ process SYLPH_PROFILE {
     script:
     def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input = meta.single_end ? "${reads}" : "-1 ${reads[0]} -2 ${reads[1]}"
+    def input = meta.single_end ? "-r ${reads}" : "-1 ${reads[0]} -2 ${reads[1]}"
     """
     sylph profile \\
-        -t $task.cpus \\
-        $args \\
-        $database\\
-        $input \\
+        -t ${task.cpus} \\
+        ${args} \\
+        ${database}\\
+        ${input} \\
         -o ${prefix}.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sylph: \$(sylph -V | awk '{print \$2}')
-    END_VERSIONS
     """
 
     stub:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
-    def input = meta.single_end ? "${reads}" : "-1 ${reads[0]} -2 ${reads[1]}"
     """
     touch ${prefix}.tsv
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sylph: \$(sylph -V | awk '{print \$2}')
-    END_VERSIONS
     """
-
 }

--- a/modules/nf-core/sylph/profile/meta.yml
+++ b/modules/nf-core/sylph/profile/meta.yml
@@ -13,7 +13,8 @@ tools:
       documentation: https://github.com/bluenote-1577/sylph
       tool_dev_url: https://github.com/bluenote-1577/sylph
       doi: 10.1038/s41587-024-02412-y
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: biotools:sylph
 input:
   - - meta:
@@ -26,24 +27,48 @@ input:
         description: |
           List of input FastQ/FASTA files of size 1 and 2 for single-end and paired-end data,
           respectively. They are automatically sketched to .sylsp/.syldb
-  - - database:
-        type: file
-        description: Pre-sketched *.syldb/*.sylsp files. Raw single-end fastq/fasta are allowed and will be automatically sketched to .sylsp/.syldb.
-        pattern: "*.{syldb,sylsp,fasta,fastq}"
+        pattern: "*.{fasta,fastq,fna,fa,fq,fas,fasta.gz,fastq.gz,fna,fa.gz,fq,fas.gz}"
+        ontologies:
+          - edam: http://edamontology.org/format_1929 # FASTA
+          - edam: http://edamontology.org/format_1930 # FASTQ
+  - database:
+      type: file
+      description: Pre-sketched *.syldb/*.sylsp files. Raw single-end fastq/fasta are
+        allowed and will be automatically sketched to .sylsp/.syldb.
+      pattern: "*.{syldb,sylsp}"
 output:
-  - profile_out:
-      - meta:
+  profile_out:
+    - - meta:
           type: map
           description: Groovy Map containing sample information
       - "*.tsv":
           type: file
-          description: Output file of species-level taxonomic profiling with abundances and ANIs.
+          description: Output file of species-level taxonomic profiling with abundances
+            and ANIs.
           pattern: "*tsv"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  versions_sylph:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sylph:
+          type: string
+          description: The tool name
+      - sylph -V | sed "s/sylph //g":
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The process the versions were collected from
+      - sylph:
+          type: string
+          description: The tool name
+      - sylph -V | sed "s/sylph //g":
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@jiahang1234"
   - "@sofstam"

--- a/modules/nf-core/sylph/profile/tests/main.nf.test
+++ b/modules/nf-core/sylph/profile/tests/main.nf.test
@@ -25,7 +25,7 @@ nextflow_process {
         then {
             assert process.success
             assert snapshot(
-                process.out.versions,
+                process.out.findAll { key, val -> key.startsWith("versions") },
                 file(process.out.profile_out[0][1]).readLines()[0]
             ).match()
         }
@@ -49,7 +49,7 @@ nextflow_process {
         then {
             assert process.success
             assert snapshot(
-                process.out.versions,
+                process.out.findAll { key, val -> key.startsWith("versions") },
                 file(process.out.profile_out[0][1]).readLines()[0]
             ).match()
         }

--- a/modules/nf-core/sylph/profile/tests/main.nf.test.snap
+++ b/modules/nf-core/sylph/profile/tests/main.nf.test.snap
@@ -1,29 +1,41 @@
 {
     "sarscov2 illumina paired-end [fastq_gz]": {
         "content": [
-            [
-                "versions.yml:md5,7b5a545483277cc0ff9189f8891e737f"
-            ],
+            {
+                "versions_sylph": [
+                    [
+                        "SYLPH_PROFILE",
+                        "sylph",
+                        "0.9.0"
+                    ]
+                ]
+            },
             "Sample_file\tGenome_file\tTaxonomic_abundance\tSequence_abundance\tAdjusted_ANI\tEff_cov\tANI_5-95_percentile\tEff_lambda\tLambda_5-95_percentile\tMedian_cov\tMean_cov_geq1\tContainment_ind\tNaive_ANI\tkmers_reassigned\tContig_name"
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-03-05T11:07:00.061876287"
+        "timestamp": "2026-04-29T16:20:14.280171765"
     },
     "sarscov2 illumina single-end [fastq_gz]": {
         "content": [
-            [
-                "versions.yml:md5,7b5a545483277cc0ff9189f8891e737f"
-            ],
+            {
+                "versions_sylph": [
+                    [
+                        "SYLPH_PROFILE",
+                        "sylph",
+                        "0.9.0"
+                    ]
+                ]
+            },
             "Sample_file\tGenome_file\tTaxonomic_abundance\tSequence_abundance\tAdjusted_ANI\tEff_cov\tANI_5-95_percentile\tEff_lambda\tLambda_5-95_percentile\tMedian_cov\tMean_cov_geq1\tContainment_ind\tNaive_ANI\tkmers_reassigned\tContig_name"
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-03-05T11:05:21.230604092"
+        "timestamp": "2026-04-29T16:20:09.29151306"
     },
     "sarscov2 illumina paired-end [fastq_gz]-stub": {
         "content": [
@@ -37,7 +49,11 @@
                     ]
                 ],
                 "1": [
-                    "versions.yml:md5,7b5a545483277cc0ff9189f8891e737f"
+                    [
+                        "SYLPH_PROFILE",
+                        "sylph",
+                        "0.9.0"
+                    ]
                 ],
                 "profile_out": [
                     [
@@ -47,15 +63,19 @@
                         "test.tsv:md5,d41d8cd98f00b204e9800998ecf8427e"
                     ]
                 ],
-                "versions": [
-                    "versions.yml:md5,7b5a545483277cc0ff9189f8891e737f"
+                "versions_sylph": [
+                    [
+                        "SYLPH_PROFILE",
+                        "sylph",
+                        "0.9.0"
+                    ]
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.4"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-03-05T11:08:35.882851964"
+        "timestamp": "2026-04-29T16:20:19.581601853"
     }
 }

--- a/modules/nf-core/sylphtax/merge/environment.yml
+++ b/modules/nf-core/sylphtax/merge/environment.yml
@@ -4,4 +4,4 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - "bioconda::sylph-tax=1.2.0"
+  - "bioconda::sylph-tax=1.9.0"

--- a/modules/nf-core/sylphtax/merge/main.nf
+++ b/modules/nf-core/sylphtax/merge/main.nf
@@ -1,13 +1,11 @@
-
 process SYLPHTAX_MERGE {
-    tag "$meta.id"
+    tag "${meta.id}"
     label 'process_single'
 
     conda "${moduleDir}/environment.yml"
-    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'https://depot.galaxyproject.org/singularity/sylph-tax:1.2.0--pyhdfd78af_0':
-        'biocontainers/sylph-tax:1.2.0--pyhdfd78af_0' }"
-
+    container "${workflow.containerEngine in ['singularity', 'apptainer'] && !task.ext.singularity_pull_docker_container
+        ? 'https://depot.galaxyproject.org/singularity/sylph-tax:1.9.0--pyhdfd78af_0'
+        : 'quay.io/biocontainers/sylph-tax:1.9.0--pyhdfd78af_0'}"
 
     input:
     tuple val(meta), path(sylphtax_reports)
@@ -15,26 +13,20 @@ process SYLPHTAX_MERGE {
 
     output:
     tuple val(meta), path("*.tsv"), emit: tsv
-    path "versions.yml"           , emit: versions
+    tuple val("${task.process}"), val('sylph-tax'), eval("sylph-tax --version 2>&1 | tail -1"), emit: versions_sylphtax, topic: versions
 
     when:
     task.ext.when == null || task.ext.when
 
     script:
-    def args = task.ext.args ?: ''
     def prefix = task.ext.prefix ?: "${meta.id}"
     """
     export SYLPH_TAXONOMY_CONFIG="/tmp/config.json"
     sylph-tax \\
         merge \\
         ${sylphtax_reports} \\
-        --column $data_type \\
+        --column ${data_type} \\
         --output ${prefix}.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sylph-tax: \$(sylph-tax --version)
-    END_VERSIONS
     """
 
     stub:
@@ -42,10 +34,5 @@ process SYLPHTAX_MERGE {
     """
     export SYLPH_TAXONOMY_CONFIG="/tmp/config.json"
     touch ${prefix}.tsv
-
-    cat <<-END_VERSIONS > versions.yml
-    "${task.process}":
-        sylph-tax: \$(sylph-tax --version)
-    END_VERSIONS
     """
 }

--- a/modules/nf-core/sylphtax/merge/meta.yml
+++ b/modules/nf-core/sylphtax/merge/meta.yml
@@ -9,7 +9,8 @@ tools:
       description: Integrating taxonomic information into the sylph metagenome profiler.
       homepage: https://github.com/bluenote-1577/sylph-tax?tab=readme-ov-file
       documentation: https://sylph-docs.github.io/sylph-tax/
-      licence: ["MIT"]
+      licence:
+        - "MIT"
       identifier: ""
 input:
   - - meta:
@@ -21,12 +22,14 @@ input:
         type: file
         description: Output taxonomic profile from sylph-tax taxprof command.
         pattern: "*.{sylphmpa}"
-  - - data_type:
-        type: string
-        description: Can be ANI, relative abundance, or sequence abundance.
+        ontologies:
+          - edam: http://edamontology.org/format_3475 # TSV
+  - data_type:
+      type: string
+      description: Can be ANI, relative abundance, or sequence abundance.
 output:
-  - tsv:
-      - meta:
+  tsv:
+    - - meta:
           type: map
           description: |
             Groovy Map containing sample information
@@ -35,11 +38,29 @@ output:
           type: file
           description: Output profile with the merged taxonomic profiles in tsv format.
           pattern: "*.tsv"
-  - versions:
-      - versions.yml:
-          type: file
-          description: File containing software versions
-          pattern: "versions.yml"
+          ontologies:
+            - edam: http://edamontology.org/format_3475 # TSV
+  versions_sylphtax:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - sylph-tax:
+          type: string
+          description: The name of the tool
+      - sylph-tax --version 2>&1 | tail -1:
+          type: eval
+          description: The expression to obtain the version of the tool
+topics:
+  versions:
+    - - ${task.process}:
+          type: string
+          description: The name of the process
+      - sylph-tax:
+          type: string
+          description: The name of the tool
+      - sylph-tax --version 2>&1 | tail -1:
+          type: eval
+          description: The expression to obtain the version of the tool
 authors:
   - "@sofstam"
 maintainers:

--- a/modules/nf-core/sylphtax/merge/tests/main.nf.test
+++ b/modules/nf-core/sylphtax/merge/tests/main.nf.test
@@ -54,7 +54,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                     process.out.tsv
                 ).match() }
             )
@@ -106,7 +106,7 @@ nextflow_process {
             assertAll(
                 { assert process.success },
                 { assert snapshot(
-                    process.out.versions,
+                    process.out.findAll { key, val -> key.startsWith("versions") },
                     process.out.tsv
                 ).match() }
             )

--- a/modules/nf-core/sylphtax/merge/tests/main.nf.test.snap
+++ b/modules/nf-core/sylphtax/merge/tests/main.nf.test.snap
@@ -1,9 +1,15 @@
 {
     "sarscov2 illumina single-end [fastq_gz]": {
         "content": [
-            [
-                "versions.yml:md5,fb665700c08de369d03e29c02394da07"
-            ],
+            {
+                "versions_sylphtax": [
+                    [
+                        "SYLPHTAX_MERGE",
+                        "sylph-tax",
+                        "1.9.0"
+                    ]
+                ]
+            },
             [
                 [
                     {
@@ -16,15 +22,21 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-04-07T15:29:34.708536546"
+        "timestamp": "2026-04-29T16:23:49.067675883"
     },
     "sarscov2 illumina single-end [fastq_gz]-stub": {
         "content": [
-            [
-                "versions.yml:md5,fb665700c08de369d03e29c02394da07"
-            ],
+            {
+                "versions_sylphtax": [
+                    [
+                        "SYLPHTAX_MERGE",
+                        "sylph-tax",
+                        "1.9.0"
+                    ]
+                ]
+            },
             [
                 [
                     {
@@ -37,8 +49,8 @@
         ],
         "meta": {
             "nf-test": "0.9.2",
-            "nextflow": "24.10.5"
+            "nextflow": "25.10.4"
         },
-        "timestamp": "2025-04-07T15:29:46.390759044"
+        "timestamp": "2026-04-29T16:24:03.103959211"
     }
 }

--- a/subworkflows/local/longread_filtering/main.nf
+++ b/subworkflows/local/longread_filtering/main.nf
@@ -21,7 +21,6 @@ workflow LONGREAD_FILTERING {
     }
     else if (params.longread_filter_tool == 'nanoq') {
         ch_filtered_reads = NANOQ(ch_reads, 'fastq.gz').reads
-        ch_versions = ch_versions.mix(NANOQ.out.versions.first())
         ch_multiqc_files = ch_multiqc_files.mix(NANOQ.out.stats)
     }
     else {

--- a/subworkflows/local/longread_hostremoval/main.nf
+++ b/subworkflows/local/longread_hostremoval/main.nf
@@ -53,7 +53,6 @@ workflow LONGREAD_HOSTREMOVAL {
     }
     else if (params.longread_hostremoval_tool == 'minimap2') {
         MINIMAP2_ALIGN(ch_reads, ch_hostremoval_index, true, 'bai', false, false)
-        ch_versions = ch_versions.mix(MINIMAP2_ALIGN.out.versions.first())
         ch_minimap2_mapped = MINIMAP2_ALIGN.out.bam.map { meta, long_reads ->
             [meta, long_reads, []]
         }

--- a/subworkflows/local/longread_hostremoval/main.nf
+++ b/subworkflows/local/longread_hostremoval/main.nf
@@ -23,7 +23,7 @@ workflow LONGREAD_HOSTREMOVAL {
     ch_multiqc_files = channel.empty()
 
     if (!params.longread_hostremoval_index && params.longread_hostremoval_tool == 'deacon') {
-        DEACON_INDEX( Channel.value([[id: ch_reference.baseName], ch_reference]) )
+        DEACON_INDEX( channel.value([[id: ch_reference.baseName], ch_reference]) )
         ch_hostremoval_index = DEACON_INDEX.out.index
     }
     else if (!params.longread_hostremoval_index && params.longread_hostremoval_tool == 'minimap2') {

--- a/subworkflows/local/nonpareil/main.nf
+++ b/subworkflows/local/nonpareil/main.nf
@@ -39,12 +39,7 @@ workflow NONPAREIL {
     NONPAREIL_NONPAREILCURVESR(ch_npos_for_nonparielset)
     // For dynamic multi-curve PNG in MultiQC and raw files
 
-    ch_versions = ch_versions.mix(
-        NONPAREIL_NONPAREIL.out.versions.first(),
-        NONPAREIL_CURVE.out.versions.first(),
-        NONPAREIL_SET.out.versions.first(),
-        NONPAREIL_NONPAREILCURVESR.out.versions.first(),
-    )
+
     ch_multiqc_files = ch_multiqc_files.mix(NONPAREIL_NONPAREILCURVESR.out.json)
 
     emit:

--- a/subworkflows/local/profiling/main.nf
+++ b/subworkflows/local/profiling/main.nf
@@ -246,7 +246,7 @@ workflow PROFILING {
     if (params.run_centrifuge) {
 
         ch_input_for_centrifuge = ch_input_for_profiling.centrifuge
-            .filter {
+            .filter { it ->
                 if (it[0].is_fasta) {
                     log.warn("[nf-core/taxprofiler] Centrifuge currently does not accept FASTA files as input. Skipping Centrifuge for sample ${it[0].id}.")
                 }
@@ -292,7 +292,7 @@ workflow PROFILING {
                 }
                 [meta, input_reads, db_meta_new, db]
                 }
-                .filter {
+                .filter { it ->
                     if (it[0].is_fasta) {
                         log.warn("[nf-core/taxprofiler] Centrifuger currently does not accept FASTA files as input. Skipping Centrifuger for sample ${it[0].id}.")
                     }
@@ -383,13 +383,13 @@ workflow PROFILING {
     if (params.run_motus) {
 
         ch_input_for_motus = ch_input_for_profiling.motus
-            .filter {
+            .filter { it ->
                 if (it[0].is_fasta) {
                     log.warn("[nf-core/taxprofiler] mOTUs currently does not accept FASTA files as input. Skipping mOTUs for sample ${it[0].id}.")
                 }
                 !it[0].is_fasta
             }
-            .branch {
+            .branch { it ->
                 longread: it[0].instrument_platform == 'OXFORD_NANOPORE' || it[0].instrument_platform == 'PACBIO_SMRT'
                 shortread: it[0].instrument_platform != 'OXFORD_NANOPORE' && it[0].instrument_platform != 'PACBIO_SMRT'
             }
@@ -580,7 +580,7 @@ workflow PROFILING {
 
     if (params.run_sylph) {
         ch_input_for_sylph = ch_input_for_profiling.sylph
-            .filter {
+            .filter { it ->
                 if (it[0].is_fasta) {
                     log.warn("[nf-core/taxprofiler] sylph currently does not accept FASTA files as input. Skipping sylph for sample ${it[0].id}.")
                 }

--- a/subworkflows/local/profiling/main.nf
+++ b/subworkflows/local/profiling/main.nf
@@ -343,6 +343,7 @@ workflow PROFILING {
         }
 
         KAIJU_KAIJU(ch_input_for_kaiju.reads, ch_input_for_kaiju.db)
+        ch_versions = ch_versions.mix(KAIJU_KAIJU.out.versions.first())
         ch_raw_classifications = ch_raw_classifications.mix(KAIJU_KAIJU.out.results)
 
         // Ensure the correct database goes with the generated report for KAIJU2TABLE

--- a/subworkflows/local/profiling/main.nf
+++ b/subworkflows/local/profiling/main.nf
@@ -177,7 +177,6 @@ workflow PROFILING {
 
         KRAKEN2_KRAKEN2(ch_input_for_kraken2.reads, ch_input_for_kraken2.db, params.kraken2_save_reads, params.kraken2_save_readclassifications)
         ch_multiqc_files = ch_multiqc_files.mix(KRAKEN2_KRAKEN2.out.report)
-        ch_versions = ch_versions.mix(KRAKEN2_KRAKEN2.out.versions.first())
         ch_raw_classifications = ch_raw_classifications.mix(KRAKEN2_KRAKEN2.out.classified_reads_assignment)
         ch_raw_profiles = ch_raw_profiles.mix(
             KRAKEN2_KRAKEN2.out.report.map { meta, report ->
@@ -239,7 +238,6 @@ workflow PROFILING {
             }
 
         BRACKEN_BRACKEN(ch_input_for_bracken.report, ch_input_for_bracken.db)
-        ch_versions = ch_versions.mix(BRACKEN_BRACKEN.out.versions.first())
         ch_raw_profiles = ch_raw_profiles.mix(BRACKEN_BRACKEN.out.reports)
     }
 
@@ -333,7 +331,6 @@ workflow PROFILING {
         }
 
         METAPHLAN_METAPHLAN(ch_input_for_metaphlan.reads, ch_input_for_metaphlan.db, params.metaphlan_save_samfiles)
-        ch_versions = ch_versions.mix(METAPHLAN_METAPHLAN.out.versions.first())
         ch_raw_profiles = ch_raw_profiles.mix(METAPHLAN_METAPHLAN.out.profile)
         ch_multiqc_files = ch_multiqc_files.mix(METAPHLAN_METAPHLAN.out.profile)
     }
@@ -346,7 +343,6 @@ workflow PROFILING {
         }
 
         KAIJU_KAIJU(ch_input_for_kaiju.reads, ch_input_for_kaiju.db)
-        ch_versions = ch_versions.mix(KAIJU_KAIJU.out.versions.first())
         ch_raw_classifications = ch_raw_classifications.mix(KAIJU_KAIJU.out.results)
 
         // Ensure the correct database goes with the generated report for KAIJU2TABLE
@@ -357,7 +353,6 @@ workflow PROFILING {
         ch_input_for_kaiju2table = combineProfilesWithDatabase(KAIJU_KAIJU.out.results, ch_database_for_kaiju2table)
         // Generate profile
         KAIJU_KAIJU2TABLE_SINGLE(ch_input_for_kaiju2table.profile, ch_input_for_kaiju2table.db, params.kaiju_taxon_rank)
-        ch_versions = ch_versions.mix(KAIJU_KAIJU2TABLE_SINGLE.out.versions)
         ch_multiqc_files = ch_multiqc_files.mix(KAIJU_KAIJU2TABLE_SINGLE.out.summary)
         ch_raw_profiles = ch_raw_profiles.mix(KAIJU_KAIJU2TABLE_SINGLE.out.summary)
     }
@@ -562,7 +557,6 @@ workflow PROFILING {
         ch_input_for_ganonclassify.reads
 
         GANON_CLASSIFY(ch_input_for_ganonclassify.reads, ch_input_for_ganonclassify.db)
-        ch_versions = ch_versions.mix(GANON_CLASSIFY.out.versions.first())
 
         ch_database_for_ganonreport = ch_databases
             .filter { meta, _db -> meta.tool == "ganon" }
@@ -571,7 +565,6 @@ workflow PROFILING {
         ch_report_for_ganonreport = combineProfilesWithDatabase(GANON_CLASSIFY.out.report, ch_database_for_ganonreport)
 
         GANON_REPORT(ch_report_for_ganonreport.profile, ch_report_for_ganonreport.db)
-        ch_versions = ch_versions.mix(GANON_REPORT.out.versions.first())
 
         // Might be flipped - check/define what is a profile vs raw classification
         ch_raw_profiles = ch_raw_profiles.mix(GANON_REPORT.out.tre)
@@ -610,7 +603,6 @@ workflow PROFILING {
             }
 
         SYLPH_PROFILE(ch_input_for_sylph.reads, ch_input_for_sylph.db)
-        ch_versions = ch_versions.mix(SYLPH_PROFILE.out.versions.first())
 
         ch_database_for_sylph_profile = ch_databases
             .filter { meta, _db -> meta.tool == 'sylph' }
@@ -673,7 +665,6 @@ workflow PROFILING {
         ch_melon_k2_db = params.melon_k2_db ? channel.fromPath(params.melon_k2_db, checkIfExists: true).collect() : []
 
         MELON(ch_input_for_melon.reads, ch_input_for_melon.db, ch_melon_k2_db)
-        ch_versions = ch_versions.mix(MELON.out.versions.first())
         ch_raw_classifications = ch_raw_classifications.mix(MELON.out.json_output)
         ch_raw_profiles = ch_raw_profiles.mix(MELON.out.tsv_output)
     }
@@ -686,7 +677,6 @@ workflow PROFILING {
         }
 
         METACACHE_QUERY(ch_input_for_metacache.reads, ch_input_for_metacache.db, params.metacache_abundances)
-        ch_versions = ch_versions.mix(METACACHE_QUERY.out.versions.first())
         ch_raw_profiles = ch_raw_profiles.mix(METACACHE_QUERY.out.mapping_results)
     }
 

--- a/subworkflows/local/shortread_adapterremoval/main.nf
+++ b/subworkflows/local/shortread_adapterremoval/main.nf
@@ -15,7 +15,7 @@ workflow SHORTREAD_ADAPTERREMOVAL {
     ch_versions = channel.empty()
     ch_multiqc_files = channel.empty()
 
-    ch_input_for_adapterremoval = ch_reads.branch {
+    ch_input_for_adapterremoval = ch_reads.branch { it ->
         single: it[0].single_end
         paired: !it[0].single_end
     }

--- a/subworkflows/local/shortread_complexityfiltering/main.nf
+++ b/subworkflows/local/shortread_complexityfiltering/main.nf
@@ -16,7 +16,6 @@ workflow SHORTREAD_COMPLEXITYFILTERING {
     // fastp complexity filtering is activated via modules.conf in shortread_preprocessing
     if (params.shortread_complexityfilter_tool == 'bbduk') {
         ch_filtered_reads = BBMAP_BBDUK(ch_reads, []).reads
-        ch_versions = ch_versions.mix(BBMAP_BBDUK.out.versions.first())
         ch_multiqc_files = ch_multiqc_files.mix(BBMAP_BBDUK.out.log)
     }
     else if (params.shortread_complexityfilter_tool == 'prinseqplusplus') {

--- a/subworkflows/local/shortread_fastp/main.nf
+++ b/subworkflows/local/shortread_fastp/main.nf
@@ -14,7 +14,7 @@ workflow SHORTREAD_FASTP {
     ch_versions = channel.empty()
     ch_multiqc_files = channel.empty()
 
-    ch_input_for_fastp = ch_reads.branch {
+    ch_input_for_fastp = ch_reads.branch { it ->
         single: it[0]['single_end'] == true
         paired: it[0]['single_end'] == false
     }

--- a/subworkflows/local/shortread_hostremoval/main.nf
+++ b/subworkflows/local/shortread_hostremoval/main.nf
@@ -23,11 +23,11 @@ workflow SHORTREAD_HOSTREMOVAL {
 
 
     if (!params.shortread_hostremoval_index && params.shortread_hostremoval_tool == 'deacon') {
-        DEACON_INDEX( Channel.value([[id: ch_reference.baseName], ch_reference]) )
+        DEACON_INDEX( channel.value([[id: ch_reference.baseName], ch_reference]) )
         ch_hostremoval_index = DEACON_INDEX.out.index
     }
     else if (ch_reference && !ch_index && params.shortread_hostremoval_tool == 'bowtie2') {
-        ch_hostremoval_index = BOWTIE2_BUILD(Channel.value([[id: ch_reference.baseName], ch_reference])).index
+        ch_hostremoval_index = BOWTIE2_BUILD(channel.value([[id: ch_reference.baseName], ch_reference])).index
     }
     else if (!ch_index && params.shortread_hostremoval_tool == 'hostile') {
         HOSTILE_FETCH_SHORTREADS(params.hostremoval_hostile_referencename)

--- a/subworkflows/local/standardisation_profiles/main.nf
+++ b/subworkflows/local/standardisation_profiles/main.nf
@@ -111,7 +111,6 @@ workflow STANDARDISATION_PROFILES {
     ch_profiles_for_bracken = groupProfiles(ch_input_profiles.bracken)
 
     BRACKEN_COMBINEBRACKENOUTPUTS(ch_profiles_for_bracken)
-    ch_versions = ch_versions.mix(BRACKEN_COMBINEBRACKENOUTPUTS.out.versions)
 
     // CENTRIFUGE
 
@@ -125,7 +124,6 @@ workflow STANDARDISATION_PROFILES {
 
     KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE(ch_profiles_for_centrifuge)
     ch_multiqc_files = ch_multiqc_files.mix(KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE.out.txt)
-    ch_versions = ch_versions.mix(KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGE.out.versions)
 
     // CENTRIFUGER
 
@@ -136,7 +134,6 @@ workflow STANDARDISATION_PROFILES {
 
     KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGER(ch_profiles_for_centrifuger)
     ch_multiqc_files = ch_multiqc_files.mix(KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGER.out.txt)
-    ch_versions = ch_versions.mix(KRAKENTOOLS_COMBINEKREPORTS_CENTRIFUGER.out.versions)
 
 
     // Kaiju
@@ -148,7 +145,6 @@ workflow STANDARDISATION_PROFILES {
 
     KAIJU_KAIJU2TABLE_COMBINED(ch_input_for_kaiju2tablecombine.profile, ch_input_for_kaiju2tablecombine.db, params.kaiju_taxon_rank)
     ch_multiqc_files = ch_multiqc_files.mix(KAIJU_KAIJU2TABLE_COMBINED.out.summary)
-    ch_versions = ch_versions.mix(KAIJU_KAIJU2TABLE_COMBINED.out.versions)
 
     // Kraken2
 
@@ -166,7 +162,6 @@ workflow STANDARDISATION_PROFILES {
 
     KRAKENTOOLS_COMBINEKREPORTS_KRAKEN(ch_profiles_for_kraken2)
     ch_multiqc_files = ch_multiqc_files.mix(KRAKENTOOLS_COMBINEKREPORTS_KRAKEN.out.txt)
-    ch_versions = ch_versions.mix(KRAKENTOOLS_COMBINEKREPORTS_KRAKEN.out.versions)
 
     // MetaPhlAn
 
@@ -174,7 +169,6 @@ workflow STANDARDISATION_PROFILES {
 
     METAPHLAN_MERGEMETAPHLANTABLES(ch_profiles_for_metaphlan)
     ch_multiqc_files = ch_multiqc_files.mix(METAPHLAN_MERGEMETAPHLANTABLES.out.txt)
-    ch_versions = ch_versions.mix(METAPHLAN_MERGEMETAPHLANTABLES.out.versions)
 
     // mOTUs
 
@@ -195,12 +189,10 @@ workflow STANDARDISATION_PROFILES {
 
     GANON_TABLE(ch_profiles_for_ganon)
     ch_multiqc_files = ch_multiqc_files.mix(GANON_TABLE.out.txt)
-    ch_versions = ch_versions.mix(GANON_TABLE.out.versions)
 
     // sylph
     ch_profiles_for_sylph = groupProfiles(ch_input_profiles.sylph)
     SYLPHTAX_MERGE(ch_profiles_for_sylph, params.sylph_data_type)
-    ch_versions = ch_versions.mix(SYLPHTAX_MERGE.out.versions)
 
     emit:
     taxpasta = TAXPASTA_MERGE.out.merged_profiles

--- a/subworkflows/local/visualization_krona/main.nf
+++ b/subworkflows/local/visualization_krona/main.nf
@@ -23,13 +23,13 @@ workflow VISUALIZATION_KRONA {
     /*
         Split profile results based on tool they come from
     */
-    ch_input_profiles = ch_profiles.branch {
+    ch_input_profiles = ch_profiles.branch { it ->
         centrifuge: it[0]['tool'] == 'centrifuge'
         centrifuger: it[0]['tool'] == 'centrifuger'
         kraken2: it[0]['tool'] == 'kraken2' || it[0]['tool'] == 'kraken2-bracken'
         unknown: true
     }
-    ch_input_classifications = ch_classifications.branch {
+    ch_input_classifications = ch_classifications.branch { it ->
         kaiju: it[0]['tool'] == 'kaiju'
         malt: it[0]['tool'] == 'malt'
         unknown: true
@@ -71,7 +71,7 @@ workflow VISUALIZATION_KRONA {
     */
 
     ch_krona_text_for_import = ch_krona_text
-        .map { [[id: it[0]['db_name'], tool: it[0]['tool']], it[1]] }
+        .map { it -> [[id: it[0]['db_name'], tool: it[0]['tool']], it[1]] }
         .groupTuple()
 
     KRONA_KTIMPORTTEXT(ch_krona_text_for_import)
@@ -85,7 +85,7 @@ workflow VISUALIZATION_KRONA {
         MEGAN_RMA2INFO_KRONA(ch_input_classifications.malt, false)
         GUNZIP(MEGAN_RMA2INFO_KRONA.out.txt)
         ch_krona_taxonomy_for_input = GUNZIP.out.gunzip
-            .map { [[id: it[0]['db_name'], tool: it[0]['tool']], it[1]] }
+            .map { it -> [[id: it[0]['db_name'], tool: it[0]['tool']], it[1]] }
             .groupTuple()
 
         KRONA_KTIMPORTTAXONOMY(ch_krona_taxonomy_for_input, file(params.krona_taxonomy_directory, checkExists: true))

--- a/subworkflows/local/visualization_krona/main.nf
+++ b/subworkflows/local/visualization_krona/main.nf
@@ -46,7 +46,6 @@ workflow VISUALIZATION_KRONA {
         .mix(ch_input_profiles.centrifuger)
     KRAKENTOOLS_KREPORT2KRONA(ch_kraken_reports)
     ch_krona_text = ch_krona_text.mix(KRAKENTOOLS_KREPORT2KRONA.out.txt)
-    ch_versions = ch_versions.mix(KRAKENTOOLS_KREPORT2KRONA.out.versions.first())
 
     /*
         Combine Kaiju profiles with their databases
@@ -64,7 +63,6 @@ workflow VISUALIZATION_KRONA {
     */
     KAIJU_KAIJU2KRONA(ch_input_for_kaiju2krona.profiles, ch_input_for_kaiju2krona.db)
     ch_krona_text = ch_krona_text.mix(KAIJU_KAIJU2KRONA.out.txt)
-    ch_versions = ch_versions.mix(KAIJU_KAIJU2KRONA.out.versions.first())
 
     /*
         Convert Krona text files into html Krona visualizations
@@ -90,8 +88,6 @@ workflow VISUALIZATION_KRONA {
 
         KRONA_KTIMPORTTAXONOMY(ch_krona_taxonomy_for_input, file(params.krona_taxonomy_directory, checkExists: true))
         ch_krona_html.mix(KRONA_KTIMPORTTAXONOMY.out.html)
-        ch_versions = ch_versions.mix(GUNZIP.out.versions.first())
-        ch_versions = ch_versions.mix(MEGAN_RMA2INFO_KRONA.out.versions.first())
         ch_versions = ch_versions.mix(KRONA_KTIMPORTTAXONOMY.out.versions.first())
     }
 

--- a/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nextflow_pipeline/main.nf
@@ -40,7 +40,7 @@ workflow UTILS_NEXTFLOW_PIPELINE {
     }
 
     emit:
-    dummy_emit = true
+        true
 }
 
 /*

--- a/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
+++ b/subworkflows/nf-core/utils_nfcore_pipeline/main.nf
@@ -13,11 +13,10 @@ workflow UTILS_NFCORE_PIPELINE {
     nextflow_cli_args
 
     main:
-    valid_config = checkConfigProvided()
     checkProfileProvided(nextflow_cli_args)
 
     emit:
-    valid_config = valid_config
+    checkConfigProvided()
 }
 
 /*

--- a/subworkflows/nf-core/utils_nfschema_plugin/main.nf
+++ b/subworkflows/nf-core/utils_nfschema_plugin/main.nf
@@ -69,5 +69,5 @@ workflow UTILS_NFSCHEMA_PLUGIN {
     }
 
     emit:
-    dummy_emit = true
+         true
 }

--- a/workflows/taxprofiler.nf
+++ b/workflows/taxprofiler.nf
@@ -195,7 +195,6 @@ workflow TAXPROFILER {
 
     if (params.perform_shortread_redundancyestimation) {
         NONPAREIL(ch_shortreads_preprocessed)
-        ch_versions = ch_versions.mix(NONPAREIL.out.versions)
     }
 
     /*
@@ -260,7 +259,6 @@ workflow TAXPROFILER {
             }
             .mix(ch_input.fasta_short, ch_input.fasta_long)
 
-        ch_versions = ch_versions.mix(MERGE_RUNS.out.versions)
     }
     else {
         ch_reads_runmerged = ch_shortreads_hostremoved.mix(ch_longreads_hostremoved, ch_input.fasta_short, ch_input.fasta_long)


### PR DESCRIPTION
Changes:

- Added explicit closure parameters (it ->) where implicit was used.
- Removed unused variable declarations.
- Renamed **Channel** factory calls to lowercase **channel** where needed.
- Updated modules to latest nf-core/modules versions (with strict-syntax fixes).


Not included:
- KMCP and motus modules kept at previous versions. Newer versions expected different number of inputs, which requires  pipeline-level updates. 
- I will handled it in a separate follow-up PR.